### PR TITLE
Fix VS build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce CRLF line endings for some Windows files that break without
+*.cmd text eol=crlf

--- a/build/vs/Engine.vcxproj
+++ b/build/vs/Engine.vcxproj
@@ -82,7 +82,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AssemblerListingLocation>Release/</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <CompileAs>CompileAsCpp</CompileAs>
       <ExceptionHandling>Sync</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -98,7 +98,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <DebugInformationFormat>
       </DebugInformationFormat>
-      <ProgramDataBaseFileName>F:\nm\Engine\Lib\neuromoreEngine_x86Windows_ReleaseStatic_VS2015_Compiler.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -107,10 +107,10 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>F:\nm\Engine\SDKs\RapidJSON\include\rapidjson;F:\nm\Engine\SDKs\zlib;F:\nm\Engine\SDKs\KissFFT;F:\nm\Engine\SDKs\KissFFT\tools;F:\nm\Engine\SDKs\spuce;F:\nm\Engine\SDKs\TinyAES;F:\nm\Engine\SDKs\EDFlib;F:\nm\Engine\SDKs\OscPack;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>F:\nm\Engine\SDKs\RapidJSON\include\rapidjson;F:\nm\Engine\SDKs\zlib;F:\nm\Engine\SDKs\KissFFT;F:\nm\Engine\SDKs\KissFFT\tools;F:\nm\Engine\SDKs\spuce;F:\nm\Engine\SDKs\TinyAES;F:\nm\Engine\SDKs\EDFlib;F:\nm\Engine\SDKs\OscPack;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
@@ -127,7 +127,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AssemblerListingLocation>Release/</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <CompileAs>CompileAsCpp</CompileAs>
       <ExceptionHandling>Sync</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -143,7 +143,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <DebugInformationFormat>
       </DebugInformationFormat>
-      <ProgramDataBaseFileName>F:\nm\Engine\Lib\neuromoreEngine_x86Windows_ReleaseStatic_VS2015_Compiler.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
@@ -152,10 +152,10 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>F:\nm\Engine\SDKs\RapidJSON\include\rapidjson;F:\nm\Engine\SDKs\zlib;F:\nm\Engine\SDKs\KissFFT;F:\nm\Engine\SDKs\KissFFT\tools;F:\nm\Engine\SDKs\spuce;F:\nm\Engine\SDKs\TinyAES;F:\nm\Engine\SDKs\EDFlib;F:\nm\Engine\SDKs\OscPack;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>F:\nm\Engine\SDKs\RapidJSON\include\rapidjson;F:\nm\Engine\SDKs\zlib;F:\nm\Engine\SDKs\KissFFT;F:\nm\Engine\SDKs\KissFFT\tools;F:\nm\Engine\SDKs\spuce;F:\nm\Engine\SDKs\TinyAES;F:\nm\Engine\SDKs\EDFlib;F:\nm\Engine\SDKs\OscPack;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
@@ -171,7 +171,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AssemblerListingLocation>Debug/</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <CompileAs>CompileAsCpp</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -192,10 +192,10 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>F:\nm\Engine\SDKs\RapidJSON\include\rapidjson;F:\nm\Engine\SDKs\zlib;F:\nm\Engine\SDKs\KissFFT;F:\nm\Engine\SDKs\KissFFT\tools;F:\nm\Engine\SDKs\spuce;F:\nm\Engine\SDKs\TinyAES;F:\nm\Engine\SDKs\EDFlib;F:\nm\Engine\SDKs\OscPack;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>F:\nm\Engine\SDKs\RapidJSON\include\rapidjson;F:\nm\Engine\SDKs\zlib;F:\nm\Engine\SDKs\KissFFT;F:\nm\Engine\SDKs\KissFFT\tools;F:\nm\Engine\SDKs\spuce;F:\nm\Engine\SDKs\TinyAES;F:\nm\Engine\SDKs\EDFlib;F:\nm\Engine\SDKs\OscPack;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
@@ -212,7 +212,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AssemblerListingLocation>Debug/</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <CompileAs>CompileAsCpp</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -234,10 +234,10 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>F:\nm\Engine\SDKs\RapidJSON\include\rapidjson;F:\nm\Engine\SDKs\zlib;F:\nm\Engine\SDKs\KissFFT;F:\nm\Engine\SDKs\KissFFT\tools;F:\nm\Engine\SDKs\spuce;F:\nm\Engine\SDKs\TinyAES;F:\nm\Engine\SDKs\EDFlib;F:\nm\Engine\SDKs\OscPack;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>F:\nm\Engine\SDKs\RapidJSON\include\rapidjson;F:\nm\Engine\SDKs\zlib;F:\nm\Engine\SDKs\KissFFT;F:\nm\Engine\SDKs\KissFFT\tools;F:\nm\Engine\SDKs\spuce;F:\nm\Engine\SDKs\TinyAES;F:\nm\Engine\SDKs\EDFlib;F:\nm\Engine\SDKs\OscPack;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>

--- a/build/vs/Neuromore.sln
+++ b/build/vs/Neuromore.sln
@@ -266,6 +266,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qt-uic", "..\..\deps\build\
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "singleapplication", "..\..\deps\build\vs\singleappliocation.vcxproj", "{07A0D17A-6E53-4B36-8FAC-9ACB0603B7BD}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B9C29AF5-8688-410B-A99C-FF62ADC05FAC} = {B9C29AF5-8688-410B-A99C-FF62ADC05FAC}
+		{B9C29AF5-8688-420B-A99C-FF62ADC05FAC} = {B9C29AF5-8688-420B-A99C-FF62ADC05FAC}
+		{B9C29AF5-8688-411B-A99C-FF62ADC05FAC} = {B9C29AF5-8688-411B-A99C-FF62ADC05FAC}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/build/vs/QtBase.vcxproj
+++ b/build/vs/QtBase.vcxproj
@@ -82,7 +82,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\deps\include;..\..\src\Engine;..\..\src\QtBase;..\..\deps\include\qt;..\..\deps\include\qt\QtBluetooth;..\..\deps\include\qt\QtCore;..\..\deps\include\qt\mkspecs\win32-msvc;..\..\deps\include\qt\QtConcurrent;..\..\deps\include\qt\QtGamepad;..\..\deps\include\qt\QtGui;..\..\deps\include\qt\QtMultimedia;..\..\deps\include\qt\QtNetwork;..\..\deps\include\qt\QtMultimediaWidgets;..\..\deps\include\qt\QtWidgets;..\..\deps\include\qt\QtOpenGL;..\..\deps\include\qt\QtPrintSupport;..\..\deps\include\qt\QtSerialPort;..\..\deps\include\qt\QtXml;..\..\src\QtBase\Mocs\include_Release;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AssemblerListingLocation>Release/</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <CompileAs>CompileAsCpp</CompileAs>
       <ExceptionHandling>Sync</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -98,7 +98,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <DebugInformationFormat>
       </DebugInformationFormat>
-      <ProgramDataBaseFileName>F:\nm\QtBase\Lib\QtBase_x86Windows_ReleaseStatic_VS2015_Compiler.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DisableSpecificWarnings>4065</DisableSpecificWarnings>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -106,10 +106,10 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;QT_NO_DEBUG;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>F:\nm\QtBase-build;F:\nm\QtBase;F:\nm\QtBase-build\QtBase_autogen\include_Release;F:\nm\QtBase\..\Engine\SDKs\spuce;F:\nm\Engine\Source;C:\Qt\5.12.4\msvc2017\include;C:\Qt\5.12.4\msvc2017\include\QtBluetooth;C:\Qt\5.12.4\msvc2017\include\QtCore;C:\Qt\5.12.4\msvc2017\.\mkspecs\win32-msvc;C:\Qt\5.12.4\msvc2017\include\QtConcurrent;C:\Qt\5.12.4\msvc2017\include\QtGamepad;C:\Qt\5.12.4\msvc2017\include\QtGui;C:\Qt\5.12.4\msvc2017\include\QtANGLE;C:\Qt\5.12.4\msvc2017\include\QtMultimedia;C:\Qt\5.12.4\msvc2017\include\QtNetwork;C:\Qt\5.12.4\msvc2017\include\QtMultimediaWidgets;C:\Qt\5.12.4\msvc2017\include\QtWidgets;C:\Qt\5.12.4\msvc2017\include\QtOpenGL;C:\Qt\5.12.4\msvc2017\include\QtPrintSupport;C:\Qt\5.12.4\msvc2017\include\QtSerialPort;C:\Qt\5.12.4\msvc2017\include\QtXml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>F:\nm\QtBase-build;F:\nm\QtBase;F:\nm\QtBase-build\QtBase_autogen\include_Release;F:\nm\QtBase\..\Engine\SDKs\spuce;F:\nm\Engine\Source;C:\Qt\5.12.4\msvc2017\include;C:\Qt\5.12.4\msvc2017\include\QtBluetooth;C:\Qt\5.12.4\msvc2017\include\QtCore;C:\Qt\5.12.4\msvc2017\.\mkspecs\win32-msvc;C:\Qt\5.12.4\msvc2017\include\QtConcurrent;C:\Qt\5.12.4\msvc2017\include\QtGamepad;C:\Qt\5.12.4\msvc2017\include\QtGui;C:\Qt\5.12.4\msvc2017\include\QtANGLE;C:\Qt\5.12.4\msvc2017\include\QtMultimedia;C:\Qt\5.12.4\msvc2017\include\QtNetwork;C:\Qt\5.12.4\msvc2017\include\QtMultimediaWidgets;C:\Qt\5.12.4\msvc2017\include\QtWidgets;C:\Qt\5.12.4\msvc2017\include\QtOpenGL;C:\Qt\5.12.4\msvc2017\include\QtPrintSupport;C:\Qt\5.12.4\msvc2017\include\QtSerialPort;C:\Qt\5.12.4\msvc2017\include\QtXml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
@@ -135,7 +135,7 @@ QtBase.cmd
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\deps\include;..\..\src\Engine;..\..\src\QtBase;..\..\deps\include\qt;..\..\deps\include\qt\QtBluetooth;..\..\deps\include\qt\QtCore;..\..\deps\include\qt\mkspecs\win32-msvc;..\..\deps\include\qt\QtConcurrent;..\..\deps\include\qt\QtGamepad;..\..\deps\include\qt\QtGui;..\..\deps\include\qt\QtMultimedia;..\..\deps\include\qt\QtNetwork;..\..\deps\include\qt\QtMultimediaWidgets;..\..\deps\include\qt\QtWidgets;..\..\deps\include\qt\QtOpenGL;..\..\deps\include\qt\QtPrintSupport;..\..\deps\include\qt\QtSerialPort;..\..\deps\include\qt\QtXml;..\..\src\QtBase\Mocs\include_Release;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AssemblerListingLocation>Release/</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <CompileAs>CompileAsCpp</CompileAs>
       <ExceptionHandling>Sync</ExceptionHandling>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -151,7 +151,7 @@ QtBase.cmd
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <DebugInformationFormat>
       </DebugInformationFormat>
-      <ProgramDataBaseFileName>F:\nm\QtBase\Lib\QtBase_x86Windows_ReleaseStatic_VS2015_Compiler.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DisableSpecificWarnings>4065</DisableSpecificWarnings>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -159,10 +159,10 @@ QtBase.cmd
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;QT_NO_DEBUG;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>F:\nm\QtBase-build;F:\nm\QtBase;F:\nm\QtBase-build\QtBase_autogen\include_Release;F:\nm\QtBase\..\Engine\SDKs\spuce;F:\nm\Engine\Source;C:\Qt\5.12.4\msvc2017\include;C:\Qt\5.12.4\msvc2017\include\QtBluetooth;C:\Qt\5.12.4\msvc2017\include\QtCore;C:\Qt\5.12.4\msvc2017\.\mkspecs\win32-msvc;C:\Qt\5.12.4\msvc2017\include\QtConcurrent;C:\Qt\5.12.4\msvc2017\include\QtGamepad;C:\Qt\5.12.4\msvc2017\include\QtGui;C:\Qt\5.12.4\msvc2017\include\QtANGLE;C:\Qt\5.12.4\msvc2017\include\QtMultimedia;C:\Qt\5.12.4\msvc2017\include\QtNetwork;C:\Qt\5.12.4\msvc2017\include\QtMultimediaWidgets;C:\Qt\5.12.4\msvc2017\include\QtWidgets;C:\Qt\5.12.4\msvc2017\include\QtOpenGL;C:\Qt\5.12.4\msvc2017\include\QtPrintSupport;C:\Qt\5.12.4\msvc2017\include\QtSerialPort;C:\Qt\5.12.4\msvc2017\include\QtXml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>F:\nm\QtBase-build;F:\nm\QtBase;F:\nm\QtBase-build\QtBase_autogen\include_Release;F:\nm\QtBase\..\Engine\SDKs\spuce;F:\nm\Engine\Source;C:\Qt\5.12.4\msvc2017\include;C:\Qt\5.12.4\msvc2017\include\QtBluetooth;C:\Qt\5.12.4\msvc2017\include\QtCore;C:\Qt\5.12.4\msvc2017\.\mkspecs\win32-msvc;C:\Qt\5.12.4\msvc2017\include\QtConcurrent;C:\Qt\5.12.4\msvc2017\include\QtGamepad;C:\Qt\5.12.4\msvc2017\include\QtGui;C:\Qt\5.12.4\msvc2017\include\QtANGLE;C:\Qt\5.12.4\msvc2017\include\QtMultimedia;C:\Qt\5.12.4\msvc2017\include\QtNetwork;C:\Qt\5.12.4\msvc2017\include\QtMultimediaWidgets;C:\Qt\5.12.4\msvc2017\include\QtWidgets;C:\Qt\5.12.4\msvc2017\include\QtOpenGL;C:\Qt\5.12.4\msvc2017\include\QtPrintSupport;C:\Qt\5.12.4\msvc2017\include\QtSerialPort;C:\Qt\5.12.4\msvc2017\include\QtXml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
@@ -187,7 +187,7 @@ QtBase.cmd
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\deps\include;..\..\src\Engine;..\..\src\QtBase;..\..\deps\include\qt;..\..\deps\include\qt\QtBluetooth;..\..\deps\include\qt\QtCore;..\..\deps\include\qt\mkspecs\win32-msvc;..\..\deps\include\qt\QtConcurrent;..\..\deps\include\qt\QtGamepad;..\..\deps\include\qt\QtGui;..\..\deps\include\qt\QtMultimedia;..\..\deps\include\qt\QtNetwork;..\..\deps\include\qt\QtMultimediaWidgets;..\..\deps\include\qt\QtWidgets;..\..\deps\include\qt\QtOpenGL;..\..\deps\include\qt\QtPrintSupport;..\..\deps\include\qt\QtSerialPort;..\..\deps\include\qt\QtXml;..\..\src\QtBase\Mocs\include_Debug;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AssemblerListingLocation>Debug/</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <CompileAs>CompileAsCpp</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -208,10 +208,10 @@ QtBase.cmd
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>F:\nm\QtBase-build;F:\nm\QtBase;F:\nm\QtBase-build\QtBase_autogen\include_Debug;F:\nm\QtBase\..\Engine\SDKs\spuce;F:\nm\Engine\Source;C:\Qt\5.12.4\msvc2017\include;C:\Qt\5.12.4\msvc2017\include\QtBluetooth;C:\Qt\5.12.4\msvc2017\include\QtCore;C:\Qt\5.12.4\msvc2017\.\mkspecs\win32-msvc;C:\Qt\5.12.4\msvc2017\include\QtConcurrent;C:\Qt\5.12.4\msvc2017\include\QtGamepad;C:\Qt\5.12.4\msvc2017\include\QtGui;C:\Qt\5.12.4\msvc2017\include\QtANGLE;C:\Qt\5.12.4\msvc2017\include\QtMultimedia;C:\Qt\5.12.4\msvc2017\include\QtNetwork;C:\Qt\5.12.4\msvc2017\include\QtMultimediaWidgets;C:\Qt\5.12.4\msvc2017\include\QtWidgets;C:\Qt\5.12.4\msvc2017\include\QtOpenGL;C:\Qt\5.12.4\msvc2017\include\QtPrintSupport;C:\Qt\5.12.4\msvc2017\include\QtSerialPort;C:\Qt\5.12.4\msvc2017\include\QtXml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>F:\nm\QtBase-build;F:\nm\QtBase;F:\nm\QtBase-build\QtBase_autogen\include_Debug;F:\nm\QtBase\..\Engine\SDKs\spuce;F:\nm\Engine\Source;C:\Qt\5.12.4\msvc2017\include;C:\Qt\5.12.4\msvc2017\include\QtBluetooth;C:\Qt\5.12.4\msvc2017\include\QtCore;C:\Qt\5.12.4\msvc2017\.\mkspecs\win32-msvc;C:\Qt\5.12.4\msvc2017\include\QtConcurrent;C:\Qt\5.12.4\msvc2017\include\QtGamepad;C:\Qt\5.12.4\msvc2017\include\QtGui;C:\Qt\5.12.4\msvc2017\include\QtANGLE;C:\Qt\5.12.4\msvc2017\include\QtMultimedia;C:\Qt\5.12.4\msvc2017\include\QtNetwork;C:\Qt\5.12.4\msvc2017\include\QtMultimediaWidgets;C:\Qt\5.12.4\msvc2017\include\QtWidgets;C:\Qt\5.12.4\msvc2017\include\QtOpenGL;C:\Qt\5.12.4\msvc2017\include\QtPrintSupport;C:\Qt\5.12.4\msvc2017\include\QtSerialPort;C:\Qt\5.12.4\msvc2017\include\QtXml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
@@ -236,7 +236,7 @@ QtBase.cmd
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\deps\include;..\..\src\Engine;..\..\src\QtBase;..\..\deps\include\qt;..\..\deps\include\qt\QtBluetooth;..\..\deps\include\qt\QtCore;..\..\deps\include\qt\mkspecs\win32-msvc;..\..\deps\include\qt\QtConcurrent;..\..\deps\include\qt\QtGamepad;..\..\deps\include\qt\QtGui;..\..\deps\include\qt\QtMultimedia;..\..\deps\include\qt\QtNetwork;..\..\deps\include\qt\QtMultimediaWidgets;..\..\deps\include\qt\QtWidgets;..\..\deps\include\qt\QtOpenGL;..\..\deps\include\qt\QtPrintSupport;..\..\deps\include\qt\QtSerialPort;..\..\deps\include\qt\QtXml;..\..\src\QtBase\Mocs\include_Debug;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AssemblerListingLocation>Debug/</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <CompileAs>CompileAsCpp</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -257,10 +257,10 @@ QtBase.cmd
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>F:\nm\QtBase-build;F:\nm\QtBase;F:\nm\QtBase-build\QtBase_autogen\include_Debug;F:\nm\QtBase\..\Engine\SDKs\spuce;F:\nm\Engine\Source;C:\Qt\5.12.4\msvc2017\include;C:\Qt\5.12.4\msvc2017\include\QtBluetooth;C:\Qt\5.12.4\msvc2017\include\QtCore;C:\Qt\5.12.4\msvc2017\.\mkspecs\win32-msvc;C:\Qt\5.12.4\msvc2017\include\QtConcurrent;C:\Qt\5.12.4\msvc2017\include\QtGamepad;C:\Qt\5.12.4\msvc2017\include\QtGui;C:\Qt\5.12.4\msvc2017\include\QtANGLE;C:\Qt\5.12.4\msvc2017\include\QtMultimedia;C:\Qt\5.12.4\msvc2017\include\QtNetwork;C:\Qt\5.12.4\msvc2017\include\QtMultimediaWidgets;C:\Qt\5.12.4\msvc2017\include\QtWidgets;C:\Qt\5.12.4\msvc2017\include\QtOpenGL;C:\Qt\5.12.4\msvc2017\include\QtPrintSupport;C:\Qt\5.12.4\msvc2017\include\QtSerialPort;C:\Qt\5.12.4\msvc2017\include\QtXml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>F:\nm\QtBase-build;F:\nm\QtBase;F:\nm\QtBase-build\QtBase_autogen\include_Debug;F:\nm\QtBase\..\Engine\SDKs\spuce;F:\nm\Engine\Source;C:\Qt\5.12.4\msvc2017\include;C:\Qt\5.12.4\msvc2017\include\QtBluetooth;C:\Qt\5.12.4\msvc2017\include\QtCore;C:\Qt\5.12.4\msvc2017\.\mkspecs\win32-msvc;C:\Qt\5.12.4\msvc2017\include\QtConcurrent;C:\Qt\5.12.4\msvc2017\include\QtGamepad;C:\Qt\5.12.4\msvc2017\include\QtGui;C:\Qt\5.12.4\msvc2017\include\QtANGLE;C:\Qt\5.12.4\msvc2017\include\QtMultimedia;C:\Qt\5.12.4\msvc2017\include\QtNetwork;C:\Qt\5.12.4\msvc2017\include\QtMultimediaWidgets;C:\Qt\5.12.4\msvc2017\include\QtWidgets;C:\Qt\5.12.4\msvc2017\include\QtOpenGL;C:\Qt\5.12.4\msvc2017\include\QtPrintSupport;C:\Qt\5.12.4\msvc2017\include\QtSerialPort;C:\Qt\5.12.4\msvc2017\include\QtXml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>

--- a/build/vs/Studio.vcxproj
+++ b/build/vs/Studio.vcxproj
@@ -488,7 +488,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>QT_NO_FONTCONFIG;QT_QPA_DEFAULT_PLATFORM_NAME="windows";WIN32;_WINDOWS;NEUROMORE_PLATFORM_WINDOWS;__TBB_NO_IMPLICIT_LINKAGE;USE_WINTHREAD;OPENSSL_STATIC;OPENSSL_NO_DYNAMIC_ENGINE;QT_LINKED_OPENSSL;QT_STATIC;PCRE2_STATIC;PCRE2_CODE_UNIT_WIDTH=16;PCRE2_STATIC;QT_STATIC;_DEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AssemblerListingLocation>Debug</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -543,7 +543,7 @@ Studio.cmd
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>QT_NO_FONTCONFIG;QT_QPA_DEFAULT_PLATFORM_NAME="windows";WIN32;_WINDOWS;NEUROMORE_PLATFORM_WINDOWS;__TBB_NO_IMPLICIT_LINKAGE;USE_WINTHREAD;OPENSSL_STATIC;OPENSSL_NO_DYNAMIC_ENGINE;QT_LINKED_OPENSSL;QT_STATIC;PCRE2_STATIC;PCRE2_CODE_UNIT_WIDTH=16;QT_STATIC;_DEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AssemblerListingLocation>Debug</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -599,7 +599,7 @@ Studio.cmd
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>None</DebugInformationFormat>
       <PreprocessorDefinitions>QT_NO_FONTCONFIG;QT_QPA_DEFAULT_PLATFORM_NAME="windows";_UNICODE;UNICODE;PCRE2_STATIC;PCRE2_CODE_UNIT_WIDTH=16;OPENSSL_STATIC;OPENSSL_NO_DYNAMIC_ENGINE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;__TBB_NO_IMPLICIT_LINKAGE;USE_WINTHREAD;QT_LINKED_OPENSSL;QT_STATIC;WIN32;_WINDOWS;QT_NO_DEBUG;NDEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AssemblerListingLocation>Release</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -667,7 +667,7 @@ Studio.cmd
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>None</DebugInformationFormat>
       <PreprocessorDefinitions>QT_NO_FONTCONFIG;QT_QPA_DEFAULT_PLATFORM_NAME="windows";WIN32;_WINDOWS;NEUROMORE_PLATFORM_WINDOWS;__TBB_NO_IMPLICIT_LINKAGE;USE_WINTHREAD;OPENSSL_STATIC;OPENSSL_NO_DYNAMIC_ENGINE;QT_LINKED_OPENSSL;QT_STATIC;QT_NO_DEBUG;PCRE2_STATIC;PCRE2_CODE_UNIT_WIDTH=16;NDEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AssemblerListingLocation>Release</AssemblerListingLocation>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <IntrinsicFunctions>true</IntrinsicFunctions>

--- a/deps/build/vs/crashrptprobe.vcxproj
+++ b/deps/build/vs/crashrptprobe.vcxproj
@@ -149,7 +149,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <DisableSpecificWarnings>4996;4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4996;4244;4312</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -236,7 +236,7 @@
       <StringPooling>true</StringPooling>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <DisableSpecificWarnings>4996;4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4996;4244;4312</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/deps/build/vs/crashsender.vcxproj
+++ b/deps/build/vs/crashsender.vcxproj
@@ -181,7 +181,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <DisableSpecificWarnings>4244;4302;4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4302;4996;4267;4311</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -274,7 +274,7 @@
       <StringPooling>true</StringPooling>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <DisableSpecificWarnings>4244;4302;4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4302;4996;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/deps/build/vs/freetype.vcxproj
+++ b/deps/build/vs/freetype.vcxproj
@@ -1255,7 +1255,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4018;4267;4312</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -1344,7 +1344,7 @@
       <StringPooling>true</StringPooling>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4018;4267;4312</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/deps/build/vs/harfbuzz-ng.vcxproj
+++ b/deps/build/vs/harfbuzz-ng.vcxproj
@@ -264,7 +264,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
@@ -352,7 +352,7 @@
       <StringPooling>true</StringPooling>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>

--- a/deps/build/vs/kissfft.vcxproj
+++ b/deps/build/vs/kissfft.vcxproj
@@ -143,7 +143,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -230,7 +230,7 @@
       <StringPooling>true</StringPooling>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/deps/build/vs/libcrypto.vcxproj
+++ b/deps/build/vs/libcrypto.vcxproj
@@ -1369,7 +1369,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <DisableSpecificWarnings>4090;4133;4244;4267;</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4090;4133;4244;4267;4164</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/deps/build/vs/libtheora.vcxproj
+++ b/deps/build/vs/libtheora.vcxproj
@@ -217,7 +217,7 @@
       <ExceptionHandling>false</ExceptionHandling>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <DisableSpecificWarnings>4018;4244;4554;4700</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4244;4554;4700;4267;4334</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -283,7 +283,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <DisableSpecificWarnings>4018;4244;4554;4700</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4244;4554;4700;4267;4334</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/deps/build/vs/tinyobjloader.vcxproj
+++ b/deps/build/vs/tinyobjloader.vcxproj
@@ -139,7 +139,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -225,7 +225,7 @@
       <StringPooling>true</StringPooling>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;HAVE_CONFIG_H;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/deps/build/vs/zlib.vcxproj
+++ b/deps/build/vs/zlib.vcxproj
@@ -218,7 +218,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader />
       <AdditionalIncludeDirectories>..\..\include\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4244;4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4996;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -267,7 +267,7 @@
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <PrecompiledHeader />
       <AdditionalIncludeDirectories>..\..\include\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4244;4996</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4996;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
f1a2743 
The 'singleapplication' project in VS was not correctly set to require qt moc/rcc/uic first (fixes VS build error)

1bf5472
Disables more compiler warnings in VS when building dependencies.

6fddfb7
Removes some incorrect hard-coded paths from vs project files (fixes VS build error)

feb8f20
Windows Batch Files (CMD) must have CLRF after checkout (fixes VS build errors)