### PR TITLE
Enable Mitsar EEG device by default

### DIFF
--- a/src/Engine/Config.h
+++ b/src/Engine/Config.h
@@ -41,7 +41,7 @@
 #ifdef NEUROMORE_PLATFORM_WINDOWS
 	// windows-only closed-source devices
 	//#define INCLUDE_DEVICE_EMOTIV
-	//#define INCLUDE_DEVICE_MITSAR
+	#define INCLUDE_DEVICE_MITSAR
 	//#define INCLUDE_DEVICE_NEUROSKY_MINDWAVE
 	//#define INCLUDE_DEVICE_TOBIIEYEX
 	// x86 only devices
@@ -81,7 +81,7 @@
 #ifdef NEUROMORE_PLATFORM_WINDOWS
 	// windows-only devices
 	//#define INCLUDE_DEVICE_EMOTIV
-	//#define INCLUDE_DEVICE_MITSAR
+	#define INCLUDE_DEVICE_MITSAR
 	//#define INCLUDE_DEVICE_NEUROSKY_MINDWAVE
 	//#define INCLUDE_DEVICE_TOBIIEYEX
 	// x86 only devices


### PR DESCRIPTION
This device does not require proprietary headers or libraries, so can be easily enabled in the build by default (like Muse).

Studio will try to start ./Mitsar/MitsarConnector.exe when you click the 'search device'  (the exe is from their SDK) which then streams to Studio using OSC.

Note:
Community Users seem to miss the rights to use the Mitsar, see rights check like:

https://github.com/neuromore/studio/blob/45e601aa8425b2bd91a7f650cf985d669a4ffd35/src/Studio/Devices/DriverInventory.cpp#L146

Unless two of them are uncommented or the community user rights are adjusted the Mitsar still won't be detected.