### PR TITLE
Fix FFT, set kissfft from float to double

### DIFF
--- a/deps/include/kissfft/kiss_fft.h
+++ b/deps/include/kissfft/kiss_fft.h
@@ -51,8 +51,8 @@ extern "C" {
 # endif
 #else
 # ifndef kiss_fft_scalar
-/*  default is float */
-#   define kiss_fft_scalar float
+/*  default is float, but we use double */
+#   define kiss_fft_scalar double
 # endif
 #endif
 


### PR DESCRIPTION
kissfft was upgraded from v130 to v131.
but used type was not switched from float (default) to double (as in old version and required).
this broke fft graph node and output view of its spectrum