### PR TITLE
Disabled Devices

### DIFF
--- a/src/Engine/DeviceDriver.cpp
+++ b/src/Engine/DeviceDriver.cpp
@@ -43,6 +43,33 @@ DeviceDriver::~DeviceDriver()
 
 void DeviceDriver::SetEnabled(bool enabled)
 {
-	mIsEnabled = enabled; 
+   if (mIsEnabled == enabled)
+      return;
+
+   mIsEnabled = enabled;
+   StartStopAutoDetection();
 }
 
+void DeviceDriver::SetAutoDetectionEnabled(bool enable)
+{
+   if (mUseAutoDetection == enable)
+      return;
+
+   mUseAutoDetection = enable;
+   StartStopAutoDetection();
+}
+
+void DeviceDriver::StartStopAutoDetection()
+{
+   // device must have auto detect support
+   if (HasAutoDetectionSupport())
+   {
+      // start
+      if (mUseAutoDetection && mIsEnabled && !IsDetectionRunning())
+         StartAutoDetection();
+
+      // stop
+      else if (!mIsEnabled || !mUseAutoDetection)
+         StopAutoDetection();
+   }
+}

--- a/src/Engine/DeviceDriver.cpp
+++ b/src/Engine/DeviceDriver.cpp
@@ -30,10 +30,8 @@
 using namespace Core;
 
 // constructor
-DeviceDriver::DeviceDriver()
+DeviceDriver::DeviceDriver(const bool enabled, const bool autodetect) : mIsEnabled(enabled), mUseAutoDetection(autodetect)
 {
-	mIsEnabled = true;
-	mUseAutoDetection = false;
 }
 
 

--- a/src/Engine/DeviceDriver.h
+++ b/src/Engine/DeviceDriver.h
@@ -68,7 +68,7 @@ class ENGINE_API DeviceDriver
 
 		// autodetection of local devices
 		virtual bool HasAutoDetectionSupport() const = 0;
-		virtual void SetAutoDetectionEnabled(bool enable = true)				{ mUseAutoDetection = enable; }
+		virtual void SetAutoDetectionEnabled(bool enable = true);
 		virtual bool IsAutoDetectionEnabled() const								{ return mUseAutoDetection; }
 		virtual void DetectDevices()											{}
 		virtual bool IsDetectionRunning() const									{ return false; }
@@ -83,6 +83,10 @@ class ENGINE_API DeviceDriver
 	protected:
 		bool mIsEnabled;
 		bool mUseAutoDetection;
+
+      virtual void StartStopAutoDetection();
+      virtual void StartAutoDetection() { } // implement with auto detection start code
+      virtual void StopAutoDetection()  { } // implement with auto detection stop code
 
 		void AddSupportedDevice(uint32 deviceTypeID)							{ mSupportedDeviceTypes.Add(deviceTypeID); }
 		Core::Array<uint32> mSupportedDeviceTypes;

--- a/src/Engine/DeviceDriver.h
+++ b/src/Engine/DeviceDriver.h
@@ -41,7 +41,7 @@ class ENGINE_API DeviceDriver
 {
 	public:
 		// constructor & destructor
-		DeviceDriver();
+		DeviceDriver(const bool enabled = true, const bool autodetect = false);
 		virtual ~DeviceDriver();
 
 		// type

--- a/src/Engine/DeviceDriver.h
+++ b/src/Engine/DeviceDriver.h
@@ -64,7 +64,7 @@ class ENGINE_API DeviceDriver
 
 		// enable/disable device driver
 		bool IsEnabled() const													{ return mIsEnabled; }
-		void SetEnabled(bool enabled = true);
+		virtual void SetEnabled(bool enabled = true);
 
 		// autodetection of local devices
 		virtual bool HasAutoDetectionSupport() const = 0;

--- a/src/Studio/Devices/ABM/AbmDriver.cpp
+++ b/src/Studio/Devices/ABM/AbmDriver.cpp
@@ -100,18 +100,19 @@ Device* AbmDriver::CreateDevice(uint32 deviceTypeID)
 // start stop auto detection
 void AbmDriver::SetAutoDetectionEnabled(bool enable)
 {
-	DeviceDriver::SetAutoDetectionEnabled(enable);
+   DeviceDriver::SetAutoDetectionEnabled(enable);
+}
 
-	if (enable == true && mIsEnabled)
-	{
-		LogDetailedInfo("Starting ABM auto detection ...");
-		mThread->Start();
-	}
-	else
-	{
-		LogDetailedInfo("Stopping ABM auto detection ...");
-		// NOTE: thread handler loop uses engine autodetection setting and stops searching for device
-	}
+void AbmDriver::StartAutoDetection()
+{
+   LogDetailedInfo("Starting ABM auto detection ...");
+   mThread->Start();
+}
+
+void AbmDriver::StopAutoDetection()
+{
+   LogDetailedInfo("Stopping ABM auto detection ...");
+   // NOTE: thread handler loop uses engine autodetection setting and stops searching for device
 }
 
 

--- a/src/Studio/Devices/ABM/AbmDriver.cpp
+++ b/src/Studio/Devices/ABM/AbmDriver.cpp
@@ -32,7 +32,7 @@
 using namespace Core;
 
 // constructor
-AbmDriver::AbmDriver() : DeviceDriver()
+AbmDriver::AbmDriver() : DeviceDriver(false)
 {
 	LogDetailedInfo("Constructing Advanced Brain Monitoring driver ...");
 
@@ -102,7 +102,7 @@ void AbmDriver::SetAutoDetectionEnabled(bool enable)
 {
 	DeviceDriver::SetAutoDetectionEnabled(enable);
 
-	if (enable == true)
+	if (enable == true && mIsEnabled)
 	{
 		LogDetailedInfo("Starting ABM auto detection ...");
 		mThread->Start();

--- a/src/Studio/Devices/ABM/AbmDriver.h
+++ b/src/Studio/Devices/ABM/AbmDriver.h
@@ -75,6 +75,10 @@ class AbmDriver : public DeviceDriver, Core::EventHandler
 
 		static Core::String GetAbmErrorAsString(int errorcode);
 
+   protected:
+      virtual void StartAutoDetection() override;
+      virtual void StopAutoDetection() override;
+
 	private:
 		void LogDeviceInfo(_DEVICE_INFO* deviceInfo);
 

--- a/src/Studio/Devices/Audio/AudioDriver.cpp
+++ b/src/Studio/Devices/Audio/AudioDriver.cpp
@@ -34,7 +34,7 @@ using namespace Core;
 
 
 // constructor
-AudioDriver::AudioDriver() : DeviceDriver(), EventHandler()
+AudioDriver::AudioDriver() : DeviceDriver(false), EventHandler()
 {
 	LogInfo("Constructing Audio device driver ...");
 

--- a/src/Studio/Devices/Bluetooth/BluetoothDriver.cpp
+++ b/src/Studio/Devices/Bluetooth/BluetoothDriver.cpp
@@ -30,7 +30,7 @@
 using namespace Core;
 
 // constructor
-BluetoothDriver::BluetoothDriver() : DeviceDriver(), EventHandler()
+BluetoothDriver::BluetoothDriver() : DeviceDriver(false), EventHandler()
 {
 	LogInfo("Constructing Bluetooth device driver ...");
 
@@ -276,7 +276,7 @@ void BluetoothDriver::SetAutoDetectionEnabled(bool enable)
 	mDetectOnce = false;
 
 	// if true and device has autodetection support: start thread
-	if (enable == true)
+	if (enable == true && mIsEnabled)
 	{
 		LogDetailedInfo("Starting Bluetooth LE device auto detection ...");
 		mAutodetectTimer->start(5000);

--- a/src/Studio/Devices/Bluetooth/BluetoothDriver.cpp
+++ b/src/Studio/Devices/Bluetooth/BluetoothDriver.cpp
@@ -270,26 +270,26 @@ bool BluetoothDriver::IsDeviceConnecting() const
 // start stop auto detection thread
 void BluetoothDriver::SetAutoDetectionEnabled(bool enable)
 {
-	// baseclass (sets flags)
-	DeviceDriver::SetAutoDetectionEnabled(enable);
-	
-	mDetectOnce = false;
+   mDetectOnce = false;
 
-	// if true and device has autodetection support: start thread
-	if (enable == true && mIsEnabled)
-	{
-		LogDetailedInfo("Starting Bluetooth LE device auto detection ...");
-		mAutodetectTimer->start(5000);
-	}
-	else
-	{
-		LogDetailedInfo("Stopping Bluetooth LE device auto detection ...");
-		mAutodetectTimer->stop();
+   // baseclass (sets flags, may call start/stop autodetection)
+   DeviceDriver::SetAutoDetectionEnabled(enable);
+}
 
-        // clear discovered devices and stop searching for new ones
-        mDiscoveredDeviceInfos.Clear();
-        mBluetoothDeviceDiscoveryAgent->stop();
-	}
+void BluetoothDriver::StartAutoDetection()
+{
+   LogDetailedInfo("Starting Bluetooth LE device auto detection ...");
+   mAutodetectTimer->start(5000);
+}
+
+void BluetoothDriver::StopAutoDetection()
+{
+   LogDetailedInfo("Stopping Bluetooth LE device auto detection ...");
+   mAutodetectTimer->stop();
+
+   // clear discovered devices and stop searching for new ones
+   mDiscoveredDeviceInfos.Clear();
+   mBluetoothDeviceDiscoveryAgent->stop();
 }
 
 

--- a/src/Studio/Devices/Bluetooth/BluetoothDriver.h
+++ b/src/Studio/Devices/Bluetooth/BluetoothDriver.h
@@ -85,6 +85,10 @@ class BluetoothDriver : public QObject, public DeviceDriver, public Core::EventH
         //void OnConnectNextDevice();
 void Connect(const QBluetoothDeviceInfo& deviceInfo);
 
+   protected:
+      virtual void StartAutoDetection() override;
+      virtual void StopAutoDetection() override;
+
 	private:
 		// device discovery
 		QTimer*								mAutodetectTimer;

--- a/src/Studio/Devices/BrainProducts/ActiChampDriver.cpp
+++ b/src/Studio/Devices/BrainProducts/ActiChampDriver.cpp
@@ -33,7 +33,7 @@
 using namespace Core;
 
 // constructor
-ActiChampDriver::ActiChampDriver() : DeviceDriver()
+ActiChampDriver::ActiChampDriver() : DeviceDriver(false)
 {
 	LogDetailedInfo("Constructing Mitsar Driver ...");
 

--- a/src/Studio/Devices/Emotiv/EmotivDriver.cpp
+++ b/src/Studio/Devices/Emotiv/EmotivDriver.cpp
@@ -37,7 +37,7 @@
 using namespace Core;
 
 // constructor
-EmotivDriver::EmotivDriver() : DeviceDriver()
+EmotivDriver::EmotivDriver() : DeviceDriver(false)
 {
 	LogDetailedInfo("Constructing Emotiv driver ...");
 

--- a/src/Studio/Devices/EyeX/TobiiEyeXDriver.cpp
+++ b/src/Studio/Devices/EyeX/TobiiEyeXDriver.cpp
@@ -32,7 +32,7 @@ TX_HANDLE mGlobalStaticHandle;
 Core::Array<double> mEyeTrackerValues;
 
 // constructor
-TobiiEyeXDriver::TobiiEyeXDriver() : DeviceDriver()
+TobiiEyeXDriver::TobiiEyeXDriver() : DeviceDriver(false)
 {
 	LogDetailedInfo("Constructing Tobii EyeX driver ...");
 	mTobiiEyeXDevice = new TobiiEyeXDevice(this);

--- a/src/Studio/Devices/Mitsar/MitsarDriver.cpp
+++ b/src/Studio/Devices/Mitsar/MitsarDriver.cpp
@@ -88,16 +88,19 @@ void MitsarDriver::Update(const Time& elapsed, const Time& delta)
 
 void MitsarDriver::SetAutoDetectionEnabled(bool enable)
 {
-	DeviceDriver::SetAutoDetectionEnabled(enable);
-	mThreadHandler->SetAutoDetectEnabled(enable);
-
-	// start thread if not already running
-	if (enable == true && mIsEnabled)
-		mThread->Start();
-	else
-		mThread->Stop();
+   mThreadHandler->SetAutoDetectEnabled(enable);
+   DeviceDriver::SetAutoDetectionEnabled(enable);
 }
 
+void MitsarDriver::StartAutoDetection()
+{
+   mThread->Start();
+}
+
+void MitsarDriver::StopAutoDetection()
+{
+   mThread->Stop();
+}
 
 bool MitsarDriver::IsDetectionRunning() const
 {

--- a/src/Studio/Devices/Mitsar/MitsarDriver.cpp
+++ b/src/Studio/Devices/Mitsar/MitsarDriver.cpp
@@ -34,7 +34,7 @@
 using namespace Core;
 
 // constructor
-MitsarDriver::MitsarDriver() : DeviceDriver()
+MitsarDriver::MitsarDriver() : DeviceDriver(false)
 {
 	LogDetailedInfo("Constructing Mitsar Driver ...");
 
@@ -92,7 +92,7 @@ void MitsarDriver::SetAutoDetectionEnabled(bool enable)
 	mThreadHandler->SetAutoDetectEnabled(enable);
 
 	// start thread if not already running
-	if (enable == true)
+	if (enable == true && mIsEnabled)
 		mThread->Start();
 	else
 		mThread->Stop();

--- a/src/Studio/Devices/Mitsar/MitsarDriver.h
+++ b/src/Studio/Devices/Mitsar/MitsarDriver.h
@@ -70,6 +70,10 @@ class MitsarDriver : public DeviceDriver, Core::EventHandler
 		void StopTest(Device* device) override;
 		bool IsTestRunning(Device* device) override;
 
+   protected:
+      virtual void StartAutoDetection() override;
+      virtual void StopAutoDetection() override;
+
 	private:
 		
 		Device*							mDevice;

--- a/src/Studio/Devices/NeuroSky/NeuroSkyDriver.cpp
+++ b/src/Studio/Devices/NeuroSky/NeuroSkyDriver.cpp
@@ -36,7 +36,7 @@
 using namespace Core;
 
 // constructor
-NeuroSkyDriver::NeuroSkyDriver() : DeviceDriver(), EventHandler()
+NeuroSkyDriver::NeuroSkyDriver() : DeviceDriver(false), EventHandler()
 {
 	LogInfo("Constructing NeuroSky device driver ...");
 
@@ -125,7 +125,7 @@ void NeuroSkyDriver::SetAutoDetectionEnabled(bool enable)
 {
 	DeviceDriver::SetAutoDetectionEnabled(enable);
 
-	if (enable == true)
+	if (enable == true && mIsEnabled)
 	{
 		LogDetailedInfo("Starting NeuroSky auto detection ...");
 		mAutoDetectionThread->start();

--- a/src/Studio/Devices/NeuroSky/NeuroSkyDriver.cpp
+++ b/src/Studio/Devices/NeuroSky/NeuroSkyDriver.cpp
@@ -123,21 +123,21 @@ void NeuroSkyDriver::Update(const Time& elapsed, const Time& delta)
 // start stop auto detection
 void NeuroSkyDriver::SetAutoDetectionEnabled(bool enable)
 {
-	DeviceDriver::SetAutoDetectionEnabled(enable);
-
-	if (enable == true && mIsEnabled)
-	{
-		LogDetailedInfo("Starting NeuroSky auto detection ...");
-		mAutoDetectionThread->start();
-		mAutoDetection->Start();
-	}
-	else
-	{
-		LogDetailedInfo("Stopping NeuroSky auto detection ...");
-		mAutoDetection->Stop();
-	}
+   DeviceDriver::SetAutoDetectionEnabled(enable);
 }
 
+void NeuroSkyDriver::StartAutoDetection()
+{
+   LogDetailedInfo("Starting NeuroSky auto detection ...");
+   mAutoDetectionThread->start();
+   mAutoDetection->Start();
+}
+
+void NeuroSkyDriver::StopAutoDetection()
+{
+   LogDetailedInfo("Stopping NeuroSky auto detection ...");
+   mAutoDetection->Stop();
+}
 
 bool NeuroSkyDriver::IsDetectionRunning() const
 {

--- a/src/Studio/Devices/NeuroSky/NeuroSkyDriver.h
+++ b/src/Studio/Devices/NeuroSky/NeuroSkyDriver.h
@@ -78,6 +78,10 @@ class NeuroSkyDriver : public QObject, public DeviceDriver, public Core::EventHa
 		// event handler (removes serial threads)
 		void OnRemoveDevice(Device* device) override;
 
+   protected:
+      virtual void StartAutoDetection() override;
+      virtual void StopAutoDetection() override;
+
 	private:
 
 		// for autodetection

--- a/src/Studio/Devices/OpenBCI/OpenBCIDriver.cpp
+++ b/src/Studio/Devices/OpenBCI/OpenBCIDriver.cpp
@@ -35,7 +35,7 @@
 using namespace Core;
 
 // constructor
-OpenBCIDriver::OpenBCIDriver() : DeviceDriver(), EventHandler()
+OpenBCIDriver::OpenBCIDriver() : DeviceDriver(false), EventHandler()
 {
 	LogInfo("Constructing OpenBCI device driver ...");
 

--- a/src/Studio/Devices/Versus/VersusDriver.cpp
+++ b/src/Studio/Devices/Versus/VersusDriver.cpp
@@ -37,7 +37,7 @@
 using namespace Core;
 
 // constructor
-VersusDriver::VersusDriver() : DeviceDriver(), EventHandler()
+VersusDriver::VersusDriver() : DeviceDriver(false), EventHandler()
 {
 	LogInfo("Constructing Versus device driver ...");
 
@@ -122,7 +122,7 @@ void VersusDriver::SetAutoDetectionEnabled(bool enable)
 {
 	DeviceDriver::SetAutoDetectionEnabled(enable);
 
-	if (enable == true)
+	if (enable == true && mIsEnabled)
 	{
 		LogDetailedInfo("Starting Versus auto detection ...");
 		mAutoDetectionThread->start();


### PR DESCRIPTION
This improves handling of disabled devices a bit, specifically related to their Auto-Detection features.

So far devices always completely initialized (e.g. started their internal threads or their auto-scanning), even if they were disabled in the configuration, now they won't anymore.

For instance, enabling "Automatic Device Search" but keeping Bluetooth devices disabled, scanned in background for bluetooth devices and prompted you with a list every n seconds, but they were supposed to be disabled. This is fixed now.

Internally, drivers now also get constructed in disabled state and may get be enabled shortly after, according to the configuration, instead of being always initialized in enabled state and later (may be) disabled (at that moment everything was kicked up already).
