### PR TITLE
Refactor Special Feedbacks

### DIFF
--- a/src/Studio/Plugins/Experience/ExperienceWidget.cpp
+++ b/src/Studio/Plugins/Experience/ExperienceWidget.cpp
@@ -511,18 +511,21 @@ MediaContent* ExperienceWidget::FindMediaContent(const char* filename)
 }
 
 
-// set the volume of a given media content
+// set the volume of a given audio or video content
 void ExperienceWidget::SetVolume(float normalizedVolume, const char* filename)
 {
 	MediaContent* mediaContent = FindMediaContent(filename);
 	if (mediaContent != NULL)
 		mediaContent->SetVolume(normalizedVolume);
+	else if (mVideoPlayer->GetUrl() == filename)
+		mVideoPlayer->SetVolumeNormalized(normalizedVolume);
 }
 
 
-// set the global volume (adjust all media contents)
+// set the global volume (adjust all audio contents + video)
 void ExperienceWidget::SetGlobalVolume(float normalizedVolume)
 {
+	mVideoPlayer->SetVolumeNormalized(normalizedVolume);
 	const uint32 numMediaItems = mMediaContents.Size();
 	for (uint32 i=0; i<numMediaItems; ++i)
 		mMediaContents[i]->SetVolume(normalizedVolume);

--- a/src/Studio/Plugins/Experience/ExperienceWidget.h
+++ b/src/Studio/Plugins/Experience/ExperienceWidget.h
@@ -96,6 +96,21 @@ class ExperienceWidget : public QWidget, public Core::EventHandler
 
 		void SetPosition(float position, const char* filename);
 
+		inline void SetBlendColor(const QColor& color) 
+		{ 
+			mBlendColor = color;
+			mPixmapBlend.fill(color);
+			update();
+		}
+		inline void SetBlendOpacity(const float opacity) 
+		{
+			if (mBlendOpacity != opacity)
+			{
+				mBlendOpacity = opacity;
+				update();
+			}
+		}
+
 		MediaContent* FindMediaContent(const char* filename);
 
 		void Clear();
@@ -134,6 +149,10 @@ class ExperienceWidget : public QWidget, public Core::EventHandler
 		QMovie*						mGifMovie;
 		
 		QPixmap						mPixmap;
+		QPixmap						mPixmapBlend;
+		QColor						mBlendColor;
+		float						mBlendOpacity;
+
 		QString						mText;
 		QColor						mTextColor;
 

--- a/src/Studio/Plugins/Experience/ExperienceWidget.h
+++ b/src/Studio/Plugins/Experience/ExperienceWidget.h
@@ -167,25 +167,9 @@ class ExperienceWidget : public QWidget, public Core::EventHandler
 		OpenCVVideoPlayer*			mVideoPlayer;
 
 #ifdef NEUROMORE_PLATFORM_WINDOWS
-
 		// windows master volume control
 		void SetSystemMasterVolume(float normalizedVolume);
 		IAudioEndpointVolume*		mEndpointVolume;
-
-		// windows screen brightness controll via gamma ramp
-		void SetScreenBrightness(double brightness);
-		void SetScreenLSD (double micrograms);
-		double mLastScreenBrightness;
-
-		typedef BOOL (WINAPI *Type_SetDeviceGammaRamp)(HDC hDC, LPVOID lpRamp);
-		HMODULE mGDI32;
-
-		Type_SetDeviceGammaRamp mGetDeviceGammaRamp;
-		Type_SetDeviceGammaRamp mSetDeviceGammaRamp;
-		
-		WORD mCurrentGammaArray[3][256];
-		WORD mOriginalGammaArray[3][256];
-
 #endif
 };
 

--- a/src/Studio/VideoPlayer.h
+++ b/src/Studio/VideoPlayer.h
@@ -34,7 +34,7 @@
 #include <QMediaPlayer>
 #include <Backend/WebDataCache.h>
 #include <time.h>
-
+#include <Math.h>
 // internal qt function
 QImage qt_imageFromVideoFrame(const QVideoFrame& f);
 
@@ -79,9 +79,16 @@ class OpenCVVideoPlayer : public QAbstractVideoSurface
       void Play(int numLoops = -1);
       void Stop();
 
+      inline const Core::String& GetUrl() const { return mUrl; }
+
       inline void Pause()           { mIsPaused = true;  mPlayer.pause(); }
       inline void Continue()        { mIsPaused = false; mPlayer.play(); }
       inline bool IsPlaying() const { return mIsPlaying; }
+      inline void SetVolume(int v)  { mPlayer.setVolume(Core::Clamp(v, 0, 100)); }
+      inline void SetVolumeNormalized(double normalizedVolume)
+      {
+         SetVolume((int)(Core::Clamp(normalizedVolume, 0.0, 1.0) * 100.0));
+      }
 
       // in milliseconds
       inline qint64 GetPosition() const { return mPlayer.position(); }

--- a/src/Studio/VideoPlayer.h
+++ b/src/Studio/VideoPlayer.h
@@ -34,7 +34,6 @@
 #include <QMediaPlayer>
 #include <Backend/WebDataCache.h>
 #include <time.h>
-#include <Math.h>
 // internal qt function
 QImage qt_imageFromVideoFrame(const QVideoFrame& f);
 


### PR DESCRIPTION
**Improves/Fixes Support for The Special Feedback Nodes**

These ones were refactored/fixed and will now work on all platforms:

* **Volume**: Controls volume of all active audio playbacks and the video playback
* **ScreenBrightness**: Controls alpha-blending of video/image playback with black (0.0=full black, 1.0=unchanged image)

This one still exists, but does work on Windows only:

* **MasterVolume**: Modifies active OS Audio-Device Volume.

This one has been removed:

* **LSD!**

All Windows GDI related code has been removed.

**Screenshot**
![special_feedbacks](https://user-images.githubusercontent.com/780159/93345541-3d149100-f833-11ea-97cc-2a6ab0ca2ca0.PNG)

