### PR TITLE
more flexible osc path pattern and id extract

### DIFF
--- a/src/Engine/Device.cpp
+++ b/src/Engine/Device.cpp
@@ -39,6 +39,7 @@ Device::Device(DeviceDriver* deviceDriver) : OscReceiver()
 	mDeviceDriver					= deviceDriver;
 	mDeviceID						= CORE_INVALIDINDEX32;
 	mName							= "";
+	mOscPathPattern					= "";
 	mState							= STATE_DISCONNECTED;
 	mLockOwner						= NULL;
 	mInactivityDuration				= 0;
@@ -493,4 +494,25 @@ Sensor* Device::AddSensor(ESensorDirection direction, const char* name, double s
 	AddSensor(sensor, direction);
 
 	return sensor;
+}
+
+int32 Device::GetOscPathDeviceId(const Core::String& address) const
+{
+	int32 deviceId = -1;
+
+	// get the number between the second pair of slashes
+	// e.g. if the address has the form "/muse/13/foobar" the result should be 13 as a decimal number
+
+	// no performance required here, so we just use strings and split them by '/'
+	Array<String> elements = address.Split(StringCharacter::forwardSlash);
+
+	// try to convert the second element of the address into a decimal number
+	if (elements.Size() > 2)
+	{
+		int32 id = elements[2].ToInt();
+		if (id >= 0 && elements[2].IsValidInt())
+			deviceId = id;
+	}
+
+	return deviceId;
 }

--- a/src/Engine/Device.h
+++ b/src/Engine/Device.h
@@ -220,6 +220,12 @@ class ENGINE_API Device : public OscReceiver, public Core::EventSource
 		virtual void StopTest() 												{ }
 		virtual bool IsTestRunning() 											{ return false; }
 
+		//
+		// OscPathPattern (e.g. /muse/*/*)
+		//
+		inline const Core::String& GetOscPathPattern() const { return mOscPathPattern; }
+		inline void SetOscPathPattern(const Core::String& s) { mOscPathPattern = s; }
+		virtual int32 GetOscPathDeviceId(const Core::String& address) const;
 
 		//
 		// Device Statistics
@@ -247,6 +253,7 @@ class ENGINE_API Device : public OscReceiver, public Core::EventSource
 		uint32						mDeviceID;						// device id for multi device support
 		DeviceConfig				mConfig;						// the device configuration (may be empty)
 		Core::String				mName;							// device instance name
+		Core::String				mOscPathPattern;				// devicec osc path pattern if any (e.g. /muse/*/*)
 		
 		void*						mLockOwner;						// exclusive access to device (for output devices)
 

--- a/src/Engine/DeviceManager.cpp
+++ b/src/Engine/DeviceManager.cpp
@@ -851,19 +851,11 @@ void DeviceManager::ProcessMessage(OscMessageParser* message)
 		Device* prototype = mRegisteredDeviceTypes[i];
 		const uint32 deviceType = prototype->GetType();
 
-		// construct osc address using the osc prefix and a wildcard for device ID
-		//mTempOscAddressPattern.Format("/%s/*/*", prototype->GetTypeName());
-		// performance optimized version
-		mTempOscAddressPattern.Clear();
-		mTempOscAddressPattern += "/";
-		mTempOscAddressPattern += prototype->GetTypeName();
-		mTempOscAddressPattern += "/*/*";
-		
-		// check if address matches the address pattern
-		if (message->MatchAddress(mTempOscAddressPattern.AsChar()))
+		// check if address matches the address pattern of the device
+		if (message->MatchAddress(prototype->GetOscPathPattern().AsChar()))
 		{
 			// try to extract device ID from the message address
-			const int32 deviceId = GetDeviceIDFromAddress(message->GetAddress());
+			const int32 deviceId = prototype->GetOscPathDeviceId(message->GetAddress());
 
 			// looks like we have a match! Create the device!
 			if (deviceId != -1)
@@ -900,29 +892,6 @@ void DeviceManager::ProcessMessage(OscMessageParser* message)
 		// mark message as processed
 		message->mIsReady = true;
 	}
-}
-
-
-int32 DeviceManager::GetDeviceIDFromAddress(const char* address) const
-{
-	int32 deviceId = -1;
-
-	// get the number between the second pair of slashes
-	// e.g. if the address has the form "/muse/13/foobar" the result should be 13 as a decimal number
-
-	// no performance required here, so we just use strings and split them by '/'
-	String addressString = address;
-	Array<String> elements = addressString.Split(StringCharacter::forwardSlash);
-
-	// try to convert the second element of the address into a decimal number
-	if (elements.Size() > 2)
-	{
-		int32 id = elements[2].ToInt();
-		if (id >= 0  && elements[2].IsValidInt())
-			deviceId = id;
-	}
-		
-	return deviceId;
 }
 
 

--- a/src/Engine/DeviceManager.h
+++ b/src/Engine/DeviceManager.h
@@ -179,9 +179,6 @@ class ENGINE_API DeviceManager : public Core::EventSource, OscReceiver
 		// misc
 		Core::String					mTempOscAddressPattern;
 		Core::FpsCounter				mFpsCounter;
-
-		// helpers
-		int32 GetDeviceIDFromAddress(const char* address) const;
 };
 
 #endif

--- a/src/Engine/Devices/Mitsar/MitsarDevices.cpp
+++ b/src/Engine/Devices/Mitsar/MitsarDevices.cpp
@@ -243,6 +243,7 @@ Mitsar201Device::Mitsar201Device(DeviceDriver* driver) : MitsarDevice(driver)
 	
 	// init with error hardware name so the device status widget will display the mitsar error image instead of the hardware image - this notifies the user that a mitsar connector is still running (e.g. because the studio crashed). This works because the real hardware name is only transmitted and set when mitsar connector is started.
 	mHardwareName = "Mitsar (Error)";
+	mOscPathPattern = "/" + Core::String(this->GetTypeName()) + "/*/*";
 
 	// create all sensors
 	CreateSensors();

--- a/src/Engine/Devices/Muse/MuseDevice.cpp
+++ b/src/Engine/Devices/Muse/MuseDevice.cpp
@@ -39,6 +39,7 @@ MuseDevice::MuseDevice(DeviceDriver* driver) : BciDevice(driver)
 	mState = STATE_IDLE;
 	mPowerSupplyType = POWERSUPPLY_BATTERY;
 	mIsTouchingForehead = 0;
+	mOscPathPattern = "/" + Core::String(this->GetTypeName()) + "/*/*";
 
 	// create all sensors
 	CreateSensors();


### PR DESCRIPTION
* Allows device classes to specify the OSC path pattern that they are interested in, instead of enforcing the old fixed pattern: `/{typename}/{int-id}/foo`
* Allows devices classes to provide the required integer device id from the OSC path whatever way they like, instead of enforcing it to be the second part in the route.
* Backwards compatible for Muse and Mitsar201 (devices already using OSC)