### PR TITLE
Improve Visualization Process Interaction

### DIFF
--- a/src/Studio/MainWindow.cpp
+++ b/src/Studio/MainWindow.cpp
@@ -2326,9 +2326,8 @@ void MainWindow::OnStartVisualization()
 	QAction*	action		= qobject_cast<QAction*>( sender() );
 	int			vizIndex	= action->property("index").toInt();
 
-	Visualization* visualization = GetManager()->GetVisualizationManager()->GetVisualization(vizIndex);
-	if (visualization != NULL)
-		visualization->Start();
+	// try to start it
+	const bool started = GetManager()->GetVisualizationManager()->Start(vizIndex);
 }
 
 

--- a/src/Studio/Plugins/ExperienceSelection/ExperienceSelectionWidget.cpp
+++ b/src/Studio/Plugins/ExperienceSelection/ExperienceSelectionWidget.cpp
@@ -29,6 +29,7 @@
 #include <Backend/FileSystemGetRequest.h>
 #include <Backend/FileSystemGetResponse.h>
 #include "../../MainWindow.h"
+#include "../../VisualizationManager.h"
 #include "../../AppManager.h"
 #include <QtBaseManager.h>
 #include <QGridLayout>
@@ -147,6 +148,10 @@ void ExperienceSelectionWidget::ReInit(bool downloadAssets)
 		CreateWidgetsForFolders(downloadAssets);
 	else
 		CreateWidgetsForFiles(downloadAssets);
+
+	// stop a running visualization
+	if (GetUser()->FindRule("STUDIO_SETTING_EasyWorkflow") != NULL)
+		GetManager()->GetVisualizationManager()->Stop();
 }
 
 

--- a/src/Studio/Plugins/SessionControl/PreSessionWidget.cpp
+++ b/src/Studio/Plugins/SessionControl/PreSessionWidget.cpp
@@ -59,10 +59,7 @@ void PreSessionWidget::Init()
 	connect( mBackToSelectionButton, &QPushButton::clicked, this, [=]
 	{
 		if (GetUser()->FindRule("STUDIO_SETTING_EasyWorkflow") != NULL)
-		{
-			GetManager()->GetVisualizationManager()->Stop();
 			GetLayoutManager()->SwitchToLayoutByName("Experience Selection");
-		}
 	});
 
 	if (GetUser()->FindRule("STUDIO_SETTING_EasyWorkflow") == NULL)

--- a/src/Studio/Plugins/SessionControl/PreSessionWidget.cpp
+++ b/src/Studio/Plugins/SessionControl/PreSessionWidget.cpp
@@ -93,7 +93,6 @@ void PreSessionWidget::Init()
 	// add the level selection button (for local ones)
 	mVisSelectionButton = new QPushButton();
 
-	GetManager()->GetVisualizationManager()->ReInit();
 	if (GetManager()->GetVisualizationManager()->GetNumVisualizations() == 0)
 		mVisSelectionButton->setEnabled(false);
 
@@ -278,10 +277,10 @@ void PreSessionWidget::OnTotalTimeChanged(double value)
 
 void PreSessionWidget::OnSelectVisualizationClicked()
 {
-	// get the visualization manager and reinitalize it
 	VisualizationManager* vizManager = GetManager()->GetVisualizationManager();
-	vizManager->ReInit();
-
-	VisualizationSelectWindow selectVizWindow(GetMainWindow());
-	selectVizWindow.exec();
+	if (vizManager->GetNumVisualizations() > 0 && !vizManager->IsRunning())
+	{
+		VisualizationSelectWindow selectVizWindow(GetMainWindow());
+		selectVizWindow.exec();
+	}
 }

--- a/src/Studio/Plugins/SessionControl/PreSessionWidget.cpp
+++ b/src/Studio/Plugins/SessionControl/PreSessionWidget.cpp
@@ -59,7 +59,10 @@ void PreSessionWidget::Init()
 	connect( mBackToSelectionButton, &QPushButton::clicked, this, [=]
 	{
 		if (GetUser()->FindRule("STUDIO_SETTING_EasyWorkflow") != NULL)
+		{
+			GetManager()->GetVisualizationManager()->Stop();
 			GetLayoutManager()->SwitchToLayoutByName("Experience Selection");
+		}
 	});
 
 	if (GetUser()->FindRule("STUDIO_SETTING_EasyWorkflow") == NULL)

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
@@ -740,13 +740,9 @@ void SessionControlPlugin::OnAfterLoadLayout()
 {
 	if (GetUser()->FindRule("STUDIO_SETTING_EasyWorkflow") != NULL)
 	{
-		// get the visualization manager and reinitalize it
+		// open visualization select window if one is available and none is running
 		VisualizationManager* vizManager = GetManager()->GetVisualizationManager();
-		vizManager->ReInit();
-
-		// open visualization select window
-		const uint32 numVisualizations = vizManager->GetNumVisualizations();
-		if (numVisualizations > 0)
+		if (vizManager->GetNumVisualizations() > 0 && !vizManager->IsRunning())
 		{
 			VisualizationSelectWindow selectVizWindow(GetMainWindow());
 			selectVizWindow.exec();

--- a/src/Studio/Visualization.cpp
+++ b/src/Studio/Visualization.cpp
@@ -83,6 +83,12 @@ bool Visualization::Start()
 
 }
 
+void Visualization::Stop()
+{
+   if (mProcess.isOpen())
+      mProcess.terminate();
+}
+
 bool Visualization::ParseFromJsonFile(const char* filename)
 {
    String folder = String(filename).ExtractPath();

--- a/src/Studio/Visualization.h
+++ b/src/Studio/Visualization.h
@@ -39,8 +39,9 @@ public:
    // true if this visualization process is running
    inline bool IsRunnning() const { return mProcess.isOpen(); }
 
-   // start the visualization
+   // start and stop the visualization
    bool Start();
+   void Stop();
 
    // parse visualization configuration
    bool ParseFromJsonFile(const char* filename);

--- a/src/Studio/Visualization.h
+++ b/src/Studio/Visualization.h
@@ -28,41 +28,51 @@
 #include <Core/StandardHeaders.h>
 #include <Core/String.h>
 #include "Config.h"
+#include <QProcess>
 
-
-class Visualization
+class Visualization : public QObject
 {
-	public:
-		Visualization();
-		virtual ~Visualization();
+public:
+   Visualization();
+   virtual ~Visualization();
 
-		// start the visualization
-		void Start();
+   // true if this visualization process is running
+   inline bool IsRunnning() const { return mProcess.isOpen(); }
 
-		bool ParseFromJsonFile(const char* filename);
+   // start the visualization
+   bool Start();
 
-		// name
-		void SetName(const char* name)								{ mName = name; }
-		const char* GetName() const									{ return mName; }
+   // parse visualization configuration
+   bool ParseFromJsonFile(const char* filename);
 
-		// description
-		void SetDescription(const char* desc)						{ mDescription = desc; }
-		const char* GetDescription() const							{ return mDescription; }
+   // name
+   inline void SetName(const char* name)              { mName = name; }
+   inline const char* GetName() const                 { return mName; }
 
-		// executable filename
-		void SetExecutableFilename(const char* filename);
-		const char* GetExecutableFilename() const					{ return mExecutableFilename; }
+   // description
+   inline void SetDescription(const char* desc)       { mDescription = desc; }
+   inline const char* GetDescription() const          { return mDescription; }
 
-		// name
-		void SetImageFilename(const char* filename)					{ mImageFilename = filename; }
-		const char* GetImageFilename() const						{ return mImageFilename; }
+   // executable filename
+   void SetExecutableFilename(const char* filename);
+   inline const char* GetExecutableFilename() const   { return mExecutableFilename; }
 
-	private:
-		Core::String	mName;
-		Core::String	mDescription;
-		Core::String	mExecutableFilename;
-		Core::String	mImageFilename;
+   // name
+   inline void SetImageFilename(const char* filename) { mImageFilename = filename; }
+   inline const char* GetImageFilename() const        { return mImageFilename; }
+
+   // qt signal handlers
+   void OnProcessStarted();
+   void OnProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+   void OnProcessStateChanged(const QProcess::ProcessState& newState);
+
+protected:
+   QProcess     mProcess;
+   QStringList  mArguments;
+   Core::String mName;
+   Core::String mDescription;
+   Core::String mExecutableFilename;
+   Core::String mImageFilename;
 };
-
 
 #endif

--- a/src/Studio/VisualizationManager.h
+++ b/src/Studio/VisualizationManager.h
@@ -41,15 +41,54 @@ class VisualizationManager : public QObject
 
 		void ReInit();
 
-		Visualization* GetVisualization(uint32 index) const								{ return mVisualizations[index]; }
-		uint32 GetNumVisualizations() const												{ return mVisualizations.Size(); }
+		inline Visualization* GetVisualization(uint32 index) const	{ return mVisualizations[index]; }
+		inline uint32 GetNumVisualizations() const							{ return mVisualizations.Size(); }
 	
+		inline bool IsRunning() const
+		{
+			const uint32_t numVis = mVisualizations.Size();
+			for (uint32 i = 0; i < numVis; i++)
+				if (mVisualizations[i]->IsRunnning())
+					return true;
+			return false;
+		}
+
+		inline uint32 GetVisualizationIndex(const Visualization* v)
+		{
+			if (v)
+			{
+				const uint32_t numVis = mVisualizations.Size();
+				for (uint32 i = 0; i < numVis; i++)
+					if (mVisualizations[i] == v)
+						return i;
+			}
+
+			return CORE_INVALIDINDEX32;
+		}
+
+		inline bool Start(uint32_t index) const
+		{
+			const uint32_t numVis = mVisualizations.Size();
+
+			// invalid index or already one running
+			if (index >= numVis || IsRunning())
+				return false;
+
+			// try start it
+			return mVisualizations[index]->Start();
+		}
+
+		inline bool Start(const Visualization* v)
+		{
+			const uint32 idx = GetVisualizationIndex(v);
+			return (idx != CORE_INVALIDINDEX32) ? Start(idx) : false;
+		}
+
 	private:
 		void Clear();
 		
 		Core::Array<Core::String>   mVisualizationFolders;
 		Core::Array<Visualization*> mVisualizations;
 };
-
 
 #endif

--- a/src/Studio/VisualizationManager.h
+++ b/src/Studio/VisualizationManager.h
@@ -84,6 +84,13 @@ class VisualizationManager : public QObject
 			return (idx != CORE_INVALIDINDEX32) ? Start(idx) : false;
 		}
 
+		inline void Stop()
+		{
+			const uint32_t numVis = mVisualizations.Size();
+			for (uint32 i = 0; i < numVis; i++)
+				if (mVisualizations[i]->IsRunnning())
+					mVisualizations[i]->Stop();
+		}
 	private:
 		void Clear();
 		

--- a/src/Studio/Windows/VisualizationSelectWindow.cpp
+++ b/src/Studio/Windows/VisualizationSelectWindow.cpp
@@ -193,7 +193,7 @@ void VisualizationSelectWidget::UpdateInterface()
 void VisualizationSelectWidget::OnSelectVisualization()
 {
 	emit VisualizationSelected();
-	mVisualization->Start();
+	GetManager()->GetVisualizationManager()->Start(mVisualization);
 }
 
 

--- a/src/Studio/Windows/VisualizationSelectWindow.cpp
+++ b/src/Studio/Windows/VisualizationSelectWindow.cpp
@@ -192,8 +192,8 @@ void VisualizationSelectWidget::UpdateInterface()
 
 void VisualizationSelectWidget::OnSelectVisualization()
 {
-	emit VisualizationSelected();
 	GetManager()->GetVisualizationManager()->Start(mVisualization);
+	emit VisualizationSelected();
 }
 
 


### PR DESCRIPTION
This makes better use of QProcess class to improve tracking of the external visualization process.

**Summary**

* A running visualization is now closed if neuromore Studio is closed.
* Prevents starting a second visualization if one is running already
* Does not open the visualization selection popup if one is running already
* Closes a running visualization if Layout is switched to "Experience Selection" (and `STUDIO_SETTING_EasyWorkflow` is set for the current user)
