### PR TITLE
Clear experience window when session is stopped

### DIFF
--- a/src/Studio/Plugins/Experience/ExperienceWidget.cpp
+++ b/src/Studio/Plugins/Experience/ExperienceWidget.cpp
@@ -607,6 +607,11 @@ void ExperienceWidget::OnExitStateReached(uint32 exitStatus)
 	Clear();
 }
 
+void ExperienceWidget::OnStopSession()
+{
+	Clear();
+}
+
 
 void ExperienceWidget::OnPlayAudio(const char* url, int32 numLoops,  double beginAt, double volume, bool allowStreaming)
 {

--- a/src/Studio/Plugins/Experience/ExperienceWidget.h
+++ b/src/Studio/Plugins/Experience/ExperienceWidget.h
@@ -63,6 +63,8 @@ class ExperienceWidget : public QWidget, public Core::EventHandler
 		// experience events
 		void OnExitStateReached(uint32 exitStatus) override;
 
+		void OnStopSession() override;
+		
 		void OnPlayAudio(const char* url, int32 numLoops, double beginAt, double volume, bool allowStream) override;
 		void OnStopAudio(const char* url) override;
 		void OnSeekAudio(const char* url, uint32 millisecs) override;

--- a/src/Studio/Plugins/Graph/GraphWidget.cpp
+++ b/src/Studio/Plugins/Graph/GraphWidget.cpp
@@ -73,7 +73,8 @@ GraphWidget::GraphWidget(Type type, GraphPlugin* plugin, QWidget* parent) : QOpe
 	mSelectStart			= QPoint( 0, 0 );
 	mSelectEnd				= QPoint( 0, 0 );
 
-	mNoGraphShownError			= "Please select a graph before starting a session";
+	mNoClassifierShownError			= "Please select a classifier from the back-end file system before starting a session";
+	mNoStateMachineShownError			= "Please select a state machine from the back-end file system before starting a session";
 	mGraphProtectionModeError	= "Due to security restrictions, the graph won't be visible.";
 
 	setAutoFillBackground(false);
@@ -233,7 +234,7 @@ void GraphWidget::paintGL()
 			mRenderer->RenderText( true, painter, mGraphProtectionModeError, mShared.GetErrorBlinkColor(), QRect(0, 0, width, height), mShared.GetStandardFont(), mShared.GetStandardFontMetrics(), Qt::AlignCenter );
 		else
 			// no graph active
-			mRenderer->RenderText( true, painter, mNoGraphShownError, mShared.GetErrorBlinkColor(), QRect(0, 0, width, height), mShared.GetStandardFont(), mShared.GetStandardFontMetrics(), Qt::AlignCenter );
+			mRenderer->RenderText( true, painter, mType == CLASSIFIER ? mNoClassifierShownError : mNoStateMachineShownError, mShared.GetErrorBlinkColor(), QRect(0, 0, width, height), mShared.GetStandardFont(), mShared.GetStandardFontMetrics(), Qt::AlignCenter );
 	}
 
 	// render selection rect

--- a/src/Studio/Plugins/Graph/GraphWidget.h
+++ b/src/Studio/Plugins/Graph/GraphWidget.h
@@ -212,7 +212,8 @@ class GraphWidget : public QOpenGLWidget, Core::EventHandler, protected QOpenGLF
 		Graph*							mShownGraph;
 		Node*							mOnMouseOverNode;
 
-		Core::String					mNoGraphShownError;
+		Core::String					mNoClassifierShownError;
+		Core::String					mNoStateMachineShownError;
 		Core::String					mGraphProtectionModeError;
 
 		GraphShared						mShared;


### PR DESCRIPTION
When we stopped a session previously the experience window wasn't cleared. Hence the video/ audio would still keep playing and also the buttons/ text would still show.
This fix clears the experience window when the Stop button is pressed in the session control plugin. 