### PR TITLE
Fixed the issue "Classifier not running in design" caused by EDF expo…

### DIFF
--- a/src/Engine/Graph/Classifier.cpp
+++ b/src/Engine/Graph/Classifier.cpp
@@ -37,7 +37,7 @@ Classifier::Classifier(Graph* parentNode) : Graph(parentNode)
 	SetName("Classifier");
 	
 	mIsDirty		= false;
-	mIsRunning		= false;
+	mIsRunning		= true;
 	mIsFinalized	= false;
 	mBufferDuration	= 10.0;
 }
@@ -175,7 +175,6 @@ void Classifier::Stop()
 			}
 		}
 	}
-	mIsRunning = false;
 }
 
 

--- a/src/Engine/Graph/Classifier.cpp
+++ b/src/Engine/Graph/Classifier.cpp
@@ -37,7 +37,6 @@ Classifier::Classifier(Graph* parentNode) : Graph(parentNode)
 	SetName("Classifier");
 	
 	mIsDirty		= false;
-	mIsRunning		= true;
 	mIsFinalized	= false;
 	mBufferDuration	= 10.0;
 }
@@ -63,7 +62,7 @@ void Classifier::Update(const Time& elapsed, const Time& delta)
 	// FIXME execute finalize only if something changed (not working correctly, ReinitAsync() is not called at every required action which leaves the classifier partially uninitialized)
 	Finalize(elapsed, delta);
 
-	if (mIsRunning == true && mCreud.Execute() == true)
+	if (mCreud.Execute() == true)
 	{
 		/////////////////////////////////////////////////////////////
 		// Phase 2: Update

--- a/src/Engine/Graph/Classifier.h
+++ b/src/Engine/Graph/Classifier.h
@@ -163,13 +163,10 @@ class ENGINE_API Classifier : public Graph, public Core::EventHandler
 		// finalize the graph (locks it and prepares it, for faster updating)
 		void Finalize(const Core::Time& elapsed, const Core::Time& delta);
 
-		// start/resume/pause classifier execution
-		void Start()														{ mIsRunning = true;}
+		// resume/pause classifier execution
 		void Pause();
 		void Continue();
 		void Stop();
-
-		bool IsRunning() const												{ return mIsRunning; }
 
 		//
 		//  Buffers
@@ -252,7 +249,6 @@ class ENGINE_API Classifier : public Graph, public Core::EventHandler
 		Core::Array<MultiChannel>				mViewSpectrumChannels;	// all view channels (Spectrum)
 		Core::Array<ViewNode*>					mViewNodeSpectrumMap;	// all the nodes that provide the spectrum channels
 
-		bool	mIsRunning;				
 		bool	mIsPaused;				
 		bool	mIsFinalized;			// true, after finalize() was called, until something is changed
 		double  mBufferDuration;		// number of seconds the buffers can take (also defines the absolute minimum update frequency)

--- a/src/Engine/Graph/FileWriterNode.cpp
+++ b/src/Engine/Graph/FileWriterNode.cpp
@@ -262,6 +262,10 @@ void FileWriterNode::Start(const Time& elapsed)
 // update the node
 void FileWriterNode::Update(const Time& elapsed, const Time& delta)
 {	
+	if (!GetSession()->IsRunning()) {
+		return;
+	}
+
 	// shared base update helper
 	if (BaseUpdate(elapsed, delta) == false)
 		return;

--- a/src/Studio/Plugins/Experience/ExperienceWidget.cpp
+++ b/src/Studio/Plugins/Experience/ExperienceWidget.cpp
@@ -214,12 +214,6 @@ void ExperienceWidget::OnFinishedPreloading()
 		stateMachine->Start();
 	}
 
-	Classifier* classifier = GetEngine()->GetActiveClassifier();
-	if (classifier != NULL)
-	{
-		classifier->Start();
-	}
-
 	// FIXME this crashes the engine sometimes during layout switch?!
 	// reset engine
 	GetEngine()->Reset();

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
@@ -498,8 +498,6 @@ void SessionControlPlugin::OnStart()
 	// load parameters
 	GetBackendInterface()->GetParameters()->Load(true, *GetSessionUser(), activeExperience, activeClassifier);
 
-	// enable the active classifier data updating.
-	activeClassifier->Start();
 }
 
 


### PR DESCRIPTION
Fixed the issue "Classifier not running in design" caused by EDF export. 

Change: set back the flag 'isRunning'  now it's true as before. 
Using session->isRunning instead. 