### PR TITLE
Fix OSX ARM64

### DIFF
--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -57,6 +57,10 @@ jobs:
         os: [macos-11,macos-12]
     steps:
 
+    # Checkout
+    - name: Checkout
+      uses: actions/checkout@v3
+
     # Download X64 Build
     - uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -12,34 +12,62 @@ jobs:
     env:
       MODE: release
       TARGET_OS: osx
+      TARGET_ARCH: ${{ matrix.arch }}
       JOBS: 4
     strategy:
       fail-fast: false
       matrix:
         os: [macos-11,macos-12]
+        arch: [x64,arm64]
     steps:
+
+    # Checkout
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Versions
-      run: |
-        make -v
-        clang++ -v
+    # Build QtTools (X64)
+    - name: Build QtTools (X64)
+      run: make TARGET_ARCH=x64 QtTools -j${{ env.JOBS }}
 
-    # X64
-    - name: Build Dependencies (X64)
-      run: make TARGET_ARCH=x64 Dependencies -j${{ env.JOBS }}
+    # Build Dependencies
+    - name: Build Dependencies
+      run: make Dependencies -j${{ env.JOBS }}
 
+    # Build
     - name: Build (X64)
-      run: make TARGET_ARCH=x64 -j${{ env.JOBS }}
+      run: make -j${{ env.JOBS }}
 
-    # ARM64
-#    - name: Build Dependencies (ARM64)
-#      run: make TARGET_ARCH=arm64 Dependencies -j${{ env.JOBS }}
+    # Upload
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: Binaries (${{ matrix.os }}-${{ matrix.arch }})
+        path: ./build/make/bin/osx-${{ matrix.arch }}/*
 
-#    - name: Build (ARM64)
-#      run: make TARGET_ARCH=arm64 -j${{ env.JOBS }}
-      
+###########################################################################         
+  dist:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-11,macos-12]
+    steps:
+
+    # Download X64 Build
+    - uses: actions/download-artifact@v2
+      with:
+        name: Binaries (${{ matrix.os }}-x64)
+        path: ./build/make/bin/osx-x64/
+
+    # Download ARM64 Build
+    - uses: actions/download-artifact@v2
+      with:
+        name: Binaries (${{ matrix.os }}-arm64)
+        path: ./build/make/bin/osx-arm64/
+
+    # Load Code Signing Certificate
     - name: Load Code Signing Certificate
       env:
         PFX_BASE64: ${{ secrets.SIGN_PFX_FILE }}
@@ -47,6 +75,7 @@ jobs:
         echo $PFX_BASE64 > ./certs/TrueCert.pfx.base64
         base64 --decode -i ./certs/TrueCert.pfx.base64 -o ./certs/TrueCert.pfx
 
+    # Pack
     - name: Distribution Packages
       env:
         SIGN_PFX_FILE: ../../certs/TrueCert.pfx
@@ -54,7 +83,8 @@ jobs:
         PUBLISHERCN: neuromore co
         PUBLISHER: CN=neuromore co, O=neuromore co, STREET=382 NE 191st St, L=Miami, S=Florida, PostalCode=33179, C=US
       run: make dist
-      
+
+    # Upload
     - name: Upload
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -42,7 +42,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Binaries (${{ matrix.os }}-${{ matrix.arch }})
-        path: ./build/make/bin/osx-${{ matrix.arch }}/*
+        path: |
+          ./build/make/bin/osx-${{ matrix.arch }}/*
+          !./build/make/bin/osx-${{ matrix.arch }}/.gitignore
 
 ###########################################################################         
   dist:

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - 'master'
 jobs:
+###########################################################################
+
   build:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 360
@@ -46,7 +48,8 @@ jobs:
           ./build/make/bin/osx-${{ matrix.arch }}/*
           !./build/make/bin/osx-${{ matrix.arch }}/.gitignore
 
-###########################################################################         
+###########################################################################
+
   dist:
     needs: build
     runs-on: ${{ matrix.os }}
@@ -62,13 +65,15 @@ jobs:
       uses: actions/checkout@v3
 
     # Download X64 Build
-    - uses: actions/download-artifact@v2
+    - name: Download X64 Build
+      uses: actions/download-artifact@v2
       with:
         name: Binaries (${{ matrix.os }}-x64)
         path: ./build/make/bin/osx-x64/
 
     # Download ARM64 Build
-    - uses: actions/download-artifact@v2
+    - name: Download ARM64 Build
+      uses: actions/download-artifact@v2
       with:
         name: Binaries (${{ matrix.os }}-arm64)
         path: ./build/make/bin/osx-arm64/

--- a/deps/build/make/platforms/dist.mk
+++ b/deps/build/make/platforms/dist.mk
@@ -117,11 +117,8 @@ dist-%: dist-prep
 dist: dist-prep dist-x64 dist-arm64
 	@echo [MKD] $(NAME).app/Contents/MacOS
 	@mkdir -p $(DISTDIR)/$(NAME).app/Contents/MacOS
-# TODO: Fix ARM-64 build and create universal binary
-	echo $(OUTDIST)
-	cp ./bin/osx-x64/$(NAME)$(EXTBIN) $(OUTDIST)
-#	@echo [LIP] $(NAME)$(EXTBIN)
-#	@lipo -create -output $(OUTDIST) \
+	@echo [LIP] $(NAME)$(EXTBIN)
+	@lipo -create -output $(OUTDIST) \
 	  ./bin/osx-x64/$(NAME)$(EXTBIN) \
 	  ./bin/osx-arm64/$(NAME)$(EXTBIN)
 	@echo [MKD] $(NAME).app/Contents/Resources

--- a/deps/src/qt-platform-cocoa/qcocoahelpers.h
+++ b/deps/src/qt-platform-cocoa/qcocoahelpers.h
@@ -178,10 +178,6 @@ T qt_mac_resolveOption(const T &fallback, QWindow *window, const QByteArray &pro
 
 // -------------------------------------------------------------------------
 
-#if !defined(Q_PROCESSOR_X86_64)
-#error "32-bit builds are not supported"
-#endif
-
 class QMacVersion
 {
 public:
@@ -254,14 +250,16 @@ template <typename T>
 struct objc_msgsend_requires_stret
 { static const bool value =
 #if defined(Q_PROCESSOR_X86)
+    #define PLATFORM_USES_SEND_SUPER_STRET 1
     // Any return value larger than two registers on i386/x86_64
     sizeof(T) > sizeof(void*) * 2;
 #elif defined(Q_PROCESSOR_ARM_32)
+    #define PLATFORM_USES_SEND_SUPER_STRET 1
     // Any return value larger than a single register on arm
     sizeof(T) >  sizeof(void*);
 #elif defined(Q_PROCESSOR_ARM_64)
-    // Stret not used on arm64
-    false;
+    #define PLATFORM_USES_SEND_SUPER_STRET 0
+    false; // Stret not used on arm64
 #endif
 };
 
@@ -281,6 +279,7 @@ ReturnType qt_msgSendSuper(id receiver, SEL selector, Args... args)
     return superFn(&sup, selector, args...);
 }
 
+#if PLATFORM_USES_SEND_SUPER_STRET
 template <typename ReturnType, typename... Args>
 ReturnType qt_msgSendSuper_stret(id receiver, SEL selector, Args... args)
 {
@@ -295,6 +294,7 @@ ReturnType qt_msgSendSuper_stret(id receiver, SEL selector, Args... args)
     superStretFn(&ret, &sup, selector, args...);
     return ret;
 }
+#endif
 
 template<typename... Args>
 class QSendSuperHelper {
@@ -335,11 +335,13 @@ private:
         return qt_msgSendSuper<ReturnType>(m_receiver, m_selector, std::get<Is>(args)...);
     }
 
+#if PLATFORM_USES_SEND_SUPER_STRET
     template <typename ReturnType, int... Is>
     if_requires_stret<ReturnType, true> msgSendSuper(std::tuple<Args...>& args, QtPrivate::IndexesList<Is...>)
     {
         return qt_msgSendSuper_stret<ReturnType>(m_receiver, m_selector, std::get<Is>(args)...);
     }
+#endif
 
     template <typename ReturnType>
     ReturnType msgSendSuper(std::tuple<Args...>& args)

--- a/deps/src/qt-platform-cocoa/qcocoahelpers.mm
+++ b/deps/src/qt-platform-cocoa/qcocoahelpers.mm
@@ -373,10 +373,6 @@ QString qt_mac_removeAmpersandEscapes(QString s)
 
 // -------------------------------------------------------------------------
 
-#if !defined(Q_PROCESSOR_X86_64)
-#error "32-bit builds are not supported"
-#endif
-
 QOperatingSystemVersion QMacVersion::buildSDK(VersionTarget target)
 {
     switch (target) {


### PR DESCRIPTION
* Fixes ARM64 build on OSX by back-porting the according Qt changes from later 5.12.10
* Enables LIPO (univeral-binary) creation in `make dist`
* Runs OSX Github builds for X64 and ARM64 in parallel