### PR TITLE
Change Display Name of App

### DIFF
--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -229,4 +229,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Packages Store (${{ matrix.os }})
-        path: ./dist/osx-10.15/*-sig.pkg
+        path: ./dist/osx-10.15/*.pkg

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -97,6 +97,7 @@ jobs:
         path: |
           ./build/make/bin/win-${{ matrix.arch }}/*.exe
           ./build/make/bin/win-${{ matrix.arch }}/*.dll
+          ./build/make/bin/win-${{ matrix.arch }}/*.pdb
 
 ###########################################################################         
   dist:

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -115,19 +115,22 @@ jobs:
       uses: actions/checkout@v3
 
     # Download X64 Build
-    - uses: actions/download-artifact@v2
+    - name: Download X64 Build
+      uses: actions/download-artifact@v2
       with:
         name: Binaries (${{ matrix.os }}-x64)
         path: ./build/make/bin/win-x64/
 
     # Download X86 Build
-    - uses: actions/download-artifact@v2
+    - name: Download X86 Build
+      uses: actions/download-artifact@v2
       with:
         name: Binaries (${{ matrix.os }}-x86)
         path: ./build/make/bin/win-x86/
 
     # Download ARM64 Build
-    - uses: actions/download-artifact@v2
+    - name: Download ARM64 Build
+      uses: actions/download-artifact@v2
       with:
         name: Binaries (${{ matrix.os }}-arm64)
         path: ./build/make/bin/win-arm64/

--- a/build/make/Studio.mk
+++ b/build/make/Studio.mk
@@ -373,22 +373,25 @@ BRANDING = neuromore
 endif
 
 ifeq ($(BRANDING),neuromore)
+APPNAME    = neuromore Studio
 DEFINES   := $(DEFINES) \
-             -DAPPNAME="neuromore Studio" \
+             -DAPPNAME="$(APPNAME)" \
              -DAPPICON="AppIcon-neuromore.ico"
 endif
 
 ifeq ($(BRANDING),ant)
+APPNAME    = eego perform studio
 DEFINES   := $(DEFINES) \
              -DNEUROMORE_BRANDING_ANT \
-             -DAPPNAME="eego perform studio" \
+             -DAPPNAME="$(APPNAME)"
              -DAPPICON="AppIcon-ANT.ico"
 endif
 
 ifeq ($(BRANDING),starrbase)
+APPNAME    = Starrbase
 DEFINES   := $(DEFINES) \
              -DNEUROMORE_BRANDING_STARRBASE \
-             -DAPPNAME="Starrbase" \
+             -DAPPNAME="$(APPNAME)"
              -DAPPICON="AppIcon-Starrbase.ico"
 endif
 

--- a/deps/build/make/platforms/dist.mk
+++ b/deps/build/make/platforms/dist.mk
@@ -285,6 +285,7 @@ dist-%: dist-prep
 	sed -i 's/{ARCH}/${DEBARCH}/g' $(DISTDIR)/$(NAME)-$*/DEBIAN/control
 	cp $(SRCDIR)/Resources/AppIcon-neuromore-256x256.png $(DISTDIR)/$(NAME)-$*/usr/share/pixmaps/$(NAME).png
 	cp $(DISTDIR)/$(NAME).desktop $(DISTDIR)/$(NAME)-$*/usr/share/applications/$(NAME).desktop
+	sed -i 's/{DISPLAYNAME}/${APPNAME}/g' $(DISTDIR)/$(NAME)-$*/usr/share/applications/$(NAME).desktop
 	cp ./bin/linux-$*/$(NAME)$(EXTBIN) $(DISTDIR)/$(NAME)-$*/usr/bin/$(NAME)$(EXTBIN)
 	@chmod +x $(DISTDIR)/$(NAME)-$*/usr/bin/$(NAME)$(EXTBIN)
 	-cp ./../../deps/prebuilt/linux/$*/*.so $(DISTDIR)/$(NAME)-$*/usr/lib/

--- a/deps/build/make/platforms/dist.mk
+++ b/deps/build/make/platforms/dist.mk
@@ -62,15 +62,19 @@ dist-prep:
 	$(call replace,$(DISTDIR)/$(NAME)/AppxManifest.xml,{PUBLISHER},$(PUBLISHER),$(DISTDIR)/$(NAME)/AppxManifest.xml)
 	$(call replace,$(DISTDIR)/$(NAME)/AppxManifest.xml,{PUBLISHERID},$(PUBLISHERID),$(DISTDIR)/$(NAME)/AppxManifest.xml)
 	$(call replace,$(DISTDIR)/$(NAME)/AppxManifest.xml,{VERSION},$(VERSION4),$(DISTDIR)/$(NAME)/AppxManifest.xml)
+	$(call replace,$(DISTDIR)/$(NAME)/AppxManifest.xml,{DISPLAYNAME},$(APPNAME),$(DISTDIR)/$(NAME)/AppxManifest.xml)
 	$(call copyfiles,$(DISTDIR)/$(NAME).layout,$(DISTDIR)/$(NAME)/Layout.xml)
 dist-%: dist-prep
-	echo [STR] ./bin/win-$*/$(NAME)$(EXTBIN)
-	$(STRIP) $(STRIPFLAGS) ./bin/win-$*/$(NAME)$(EXTBIN)
-	echo [SIG] ./bin/win-$*/$(NAME)$(EXTBIN)
+	$(call rmdir,$(DISTDIR)/$(NAME)/$*)
+	$(call mkdir,$(DISTDIR)/$(NAME)/$*)
+	$(call copyfiles,./bin/win-$*/$(NAME)$(EXTBIN),$(DISTDIR)/$(NAME)/$*/$(NAME)$(EXTBIN))
+	echo [STR] $(DISTDIR)/$(NAME)/$*/$(NAME)$(EXTBIN)
+	$(STRIP) $(STRIPFLAGS) $(DISTDIR)/$(NAME)/$*/$(NAME)$(EXTBIN)
+	echo [SIG] $(DISTDIR)/$(NAME)/$*/$(NAME)$(EXTBIN)
 ifeq ($(SIGN_PFX_PASS),)
-	$(call sign,./bin/win-$*/$(NAME)$(EXTBIN),$(SIGN_PFX_FILE))
+	$(call sign,$(DISTDIR)/$(NAME)/$*/$(NAME)$(EXTBIN),$(SIGN_PFX_FILE))
 else
-	$(call signp,./bin/win-$*/$(NAME)$(EXTBIN),$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
+	$(call signp,$(DISTDIR)/$(NAME)/$*/$(NAME)$(EXTBIN),$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
 endif
 dist: dist-prep dist-x64 dist-x86 dist-arm64
 	echo [BDL] $(NAME).appxbundle

--- a/deps/build/make/platforms/dist.mk
+++ b/deps/build/make/platforms/dist.mk
@@ -64,6 +64,7 @@ dist-prep:
 	$(call replace,$(DISTDIR)/$(NAME)/AppxManifest.xml,{VERSION},$(VERSION4),$(DISTDIR)/$(NAME)/AppxManifest.xml)
 	$(call replace,$(DISTDIR)/$(NAME)/AppxManifest.xml,{DISPLAYNAME},$(APPNAME),$(DISTDIR)/$(NAME)/AppxManifest.xml)
 	$(call copyfiles,$(DISTDIR)/$(NAME).layout,$(DISTDIR)/$(NAME)/Layout.xml)
+	$(call replace,$(DISTDIR)/$(NAME)/Layout.xml,{VERSION},$(VERSION3),$(DISTDIR)/$(NAME)/Layout.xml)
 dist-%: dist-prep
 	$(call rmdir,$(DISTDIR)/$(NAME)/$*)
 	$(call mkdir,$(DISTDIR)/$(NAME)/$*)
@@ -77,19 +78,19 @@ else
 	$(call signp,$(DISTDIR)/$(NAME)/$*/$(NAME)$(EXTBIN),$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
 endif
 dist: dist-prep dist-x64 dist-x86 dist-arm64
-	echo [BDL] $(NAME).appxbundle
+	echo [BDL] $(NAME)-$(VERSION3).appxbundle
 	$(call makepkg,$(DISTDIR)/$(NAME)/Layout.xml,$(DISTDIR))
-	echo [SIG] $(DISTDIR)/$(NAME).appxbundle
+	echo [SIG] $(DISTDIR)/$(NAME)-$(VERSION3).appxbundle
 ifeq ($(SIGN_PFX_PASS),)
-	$(call sign,$(DISTDIR)/$(NAME).appxbundle,$(SIGN_PFX_FILE))
-	$(call sign,$(DISTDIR)/$(NAME)-x64.appx,$(SIGN_PFX_FILE))
-	$(call sign,$(DISTDIR)/$(NAME)-x86.appx,$(SIGN_PFX_FILE))
-	$(call sign,$(DISTDIR)/$(NAME)-arm64.appx,$(SIGN_PFX_FILE))
+	$(call sign,$(DISTDIR)/$(NAME)-$(VERSION3).appxbundle,$(SIGN_PFX_FILE))
+	$(call sign,$(DISTDIR)/$(NAME)-$(VERSION3)-x64.appx,$(SIGN_PFX_FILE))
+	$(call sign,$(DISTDIR)/$(NAME)-$(VERSION3)-x86.appx,$(SIGN_PFX_FILE))
+	$(call sign,$(DISTDIR)/$(NAME)-$(VERSION3)-arm64.appx,$(SIGN_PFX_FILE))
 else
-	$(call signp,$(DISTDIR)/$(NAME).appxbundle,$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
-	$(call signp,$(DISTDIR)/$(NAME)-x64.appx,$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
-	$(call signp,$(DISTDIR)/$(NAME)-x86.appx,$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
-	$(call signp,$(DISTDIR)/$(NAME)-arm64.appx,$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
+	$(call signp,$(DISTDIR)/$(NAME)-$(VERSION3).appxbundle,$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
+	$(call signp,$(DISTDIR)/$(NAME)-$(VERSION3)-x64.appx,$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
+	$(call signp,$(DISTDIR)/$(NAME)-$(VERSION3)-x86.appx,$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
+	$(call signp,$(DISTDIR)/$(NAME)-$(VERSION3)-arm64.appx,$(SIGN_PFX_FILE),$(SIGN_PFX_PASS))
 endif
 
 endif

--- a/dist/osx-10.15/Studio.Component.plist
+++ b/dist/osx-10.15/Studio.Component.plist
@@ -4,7 +4,7 @@
 <array>
   <dict>
     <key>RootRelativeBundlePath</key>
-    <string>Studio.app</string>
+    <string>neuromore Studio.app</string>
     <key>BundleHasStrictIdentifier</key>
     <true/>
     <key>BundleIsRelocatable</key>

--- a/dist/osx-10.15/Studio.Info.plist
+++ b/dist/osx-10.15/Studio.Info.plist
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleName</key>
-	<string>Studio</string>
+	<string>NMStudio</string>
+	<key>CFBundleDisplayName</key>
+	<string>neuromore Studio</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.neuromore.studio</string>
 	<key>LSApplicationCategoryType</key>

--- a/dist/osx-10.15/Studio.Info.plist
+++ b/dist/osx-10.15/Studio.Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleName</key>
 	<string>NMStudio</string>
-	<key>CFBundleDisplayName</key>
-	<string>neuromore Studio</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.neuromore.studio</string>
 	<key>LSApplicationCategoryType</key>

--- a/dist/ubuntu-20.04/Studio.desktop
+++ b/dist/ubuntu-20.04/Studio.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name={DISPLAYNAME}
-Comment=neuromore Studio
+Comment=Your IDE for neuro-tech apps
 Exec=/usr/bin/Studio
 Icon=/usr/share/pixmaps/Studio.png
 Terminal=true

--- a/dist/ubuntu-20.04/Studio.desktop
+++ b/dist/ubuntu-20.04/Studio.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Studio
+Name={DISPLAYNAME}
 Comment=neuromore Studio
 Exec=/usr/bin/Studio
 Icon=/usr/share/pixmaps/Studio.png

--- a/dist/ubuntu-22.04/Studio.desktop
+++ b/dist/ubuntu-22.04/Studio.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name={DISPLAYNAME}
-Comment=neuromore Studio
+Comment=Your IDE for neuro-tech apps
 Exec=/usr/bin/Studio
 Icon=/usr/share/pixmaps/Studio.png
 Terminal=true

--- a/dist/ubuntu-22.04/Studio.desktop
+++ b/dist/ubuntu-22.04/Studio.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Studio
+Name={DISPLAYNAME}
 Comment=neuromore Studio
 Exec=/usr/bin/Studio
 Icon=/usr/share/pixmaps/Studio.png

--- a/dist/win-10/Studio.appxmanifest
+++ b/dist/win-10/Studio.appxmanifest
@@ -19,7 +19,7 @@
 	ProcessorArchitecture="neutral"	/>
 
   <Properties>
-    <DisplayName>Studio</DisplayName>
+    <DisplayName>{DISPLAYNAME}</DisplayName>
     <PublisherDisplayName>neuromore co</PublisherDisplayName>
     <Logo>app.png</Logo>
   </Properties>
@@ -41,10 +41,10 @@
       desktop4:SupportsMultipleInstances="true">
 	  
       <uap:VisualElements 
-        DisplayName="Studio" 
+        DisplayName="{DISPLAYNAME}" 
         Square150x150Logo="app.png" 
         Square44x44Logo="app.png"
-        Description="Studio"
+        Description="neuromore Studio"
         BackgroundColor="transparent">		
         <uap:DefaultTile Wide310x150Logo="app.png">
           <uap:ShowNameOnTiles>

--- a/dist/win-10/Studio.appxmanifest
+++ b/dist/win-10/Studio.appxmanifest
@@ -44,7 +44,7 @@
         DisplayName="{DISPLAYNAME}" 
         Square150x150Logo="app.png" 
         Square44x44Logo="app.png"
-        Description="neuromore Studio"
+        Description="Your IDE for neuro-tech apps"
         BackgroundColor="transparent">		
         <uap:DefaultTile Wide310x150Logo="app.png">
           <uap:ShowNameOnTiles>

--- a/dist/win-10/Studio.layout
+++ b/dist/win-10/Studio.layout
@@ -7,7 +7,7 @@
     
     <Package ID="Studio-x64" ProcessorArchitecture="x64">
       <Files>
-        <File DestinationPath="Studio.exe" SourcePath="../../build/make/bin/win-x64/Studio.exe"/>
+        <File DestinationPath="Studio.exe" SourcePath="../../dist/win-10/Studio/x64/Studio.exe"/>
         <File DestinationPath="app.png" SourcePath="../../src/Studio/Resources/AppIcon-neuromore-256x256.png"/>
         <File DestinationPath="eego-SDK.dll" SourcePath="../../deps/prebuilt/win/x64/eego-SDK.dll"/>
         <File DestinationPath="gforce64.dll" SourcePath="../../deps/prebuilt/win/x64/gforce64.dll"/>
@@ -18,7 +18,7 @@
 	
     <Package ID="Studio-x86" ProcessorArchitecture="x86">
       <Files>
-        <File DestinationPath="Studio.exe" SourcePath="../../build/make/bin/win-x86/Studio.exe"/>
+        <File DestinationPath="Studio.exe" SourcePath="../../dist/win-10/Studio/x86/Studio.exe"/>
         <File DestinationPath="app.png" SourcePath="../../src/Studio/Resources/AppIcon-neuromore-256x256.png"/>
         <File DestinationPath="eego-SDK.dll" SourcePath="../../deps/prebuilt/win/x86/eego-SDK.dll"/>
         <File DestinationPath="gforce32.dll" SourcePath="../../deps/prebuilt/win/x86/gforce32.dll"/>
@@ -28,7 +28,7 @@
 	
     <Package ID="Studio-arm64" ProcessorArchitecture="arm64">
       <Files>
-        <File DestinationPath="Studio.exe" SourcePath="../../build/make/bin/win-arm64/Studio.exe"/>
+        <File DestinationPath="Studio.exe" SourcePath="../../dist/win-10/Studio/arm64/Studio.exe"/>
         <File DestinationPath="app.png" SourcePath="../../src/Studio/Resources/AppIcon-neuromore-256x256.png"/>
       </Files>
     </Package>

--- a/dist/win-10/Studio.layout
+++ b/dist/win-10/Studio.layout
@@ -1,11 +1,11 @@
 <PackagingLayout xmlns="http://schemas.microsoft.com/appx/makeappx/2017">
   <PackageFamily 
-    ID="Studio" 
+    ID="Studio-{VERSION}" 
     FlatBundle="false"
     ManifestPath="../../dist/win-10/Studio/AppxManifest.xml"
     ResourceManager="false">
     
-    <Package ID="Studio-x64" ProcessorArchitecture="x64">
+    <Package ID="Studio-{VERSION}-x64" ProcessorArchitecture="x64">
       <Files>
         <File DestinationPath="Studio.exe" SourcePath="../../dist/win-10/Studio/x64/Studio.exe"/>
         <File DestinationPath="app.png" SourcePath="../../src/Studio/Resources/AppIcon-neuromore-256x256.png"/>
@@ -16,7 +16,7 @@
       </Files>
     </Package>
 	
-    <Package ID="Studio-x86" ProcessorArchitecture="x86">
+    <Package ID="Studio-{VERSION}-x86" ProcessorArchitecture="x86">
       <Files>
         <File DestinationPath="Studio.exe" SourcePath="../../dist/win-10/Studio/x86/Studio.exe"/>
         <File DestinationPath="app.png" SourcePath="../../src/Studio/Resources/AppIcon-neuromore-256x256.png"/>
@@ -26,7 +26,7 @@
       </Files>
     </Package>
 	
-    <Package ID="Studio-arm64" ProcessorArchitecture="arm64">
+    <Package ID="Studio-{VERSION}-arm64" ProcessorArchitecture="arm64">
       <Files>
         <File DestinationPath="Studio.exe" SourcePath="../../dist/win-10/Studio/arm64/Studio.exe"/>
         <File DestinationPath="app.png" SourcePath="../../src/Studio/Resources/AppIcon-neuromore-256x256.png"/>


### PR DESCRIPTION
**ALL**
* Changes the product name shown with icons, shortcuts (and in macOS Applications) from `Studio` to `neuromore Studio`

**WIN**
* Adds version number to filename of built packages, e.g. `Studio-1.6.4.appxbundle`
* Adds .PDB debug symbols to Github artifact `Binaries`
* Sets the short description in the package to `Your IDE for neuro-tech apps` (equal to macOS Store entry subtitle)
* Copies the binaries to the dist folder before doing anything with it (fixes issues with running repeated `make dist`)

**OSX**
* Adds version number to filename of built packages, e.g. `Studio-1.6.4.pkg`
* Renames unsigned macOS package from `NAME.pkg` to `NAME-unsigned.pkg` and uses without suffix for signed one.
* Cleans up the created dist folder files before creating new one (fixes issues with running repeated `make dist`)

**LINUX**
* Sets `Comment` property of `.desktop` to `Your IDE for neuro-tech apps` (equal to macOS Store entry subtitle)
