### PR TITLE
Win10 Package Fixes | Tweaks

### DIFF
--- a/build/vs/Engine.vcxproj
+++ b/build/vs/Engine.vcxproj
@@ -173,6 +173,7 @@
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <OmitFramePointers>true</OmitFramePointers>
       <PrecompiledHeaderFile>Engine/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -219,6 +220,7 @@
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <OmitFramePointers>true</OmitFramePointers>
       <PrecompiledHeaderFile>Engine/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -265,6 +267,7 @@
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <OmitFramePointers>true</OmitFramePointers>
       <PrecompiledHeaderFile>Engine/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -311,6 +314,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <PrecompiledHeaderFile>Engine/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -356,6 +360,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <PrecompiledHeaderFile>Engine/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -401,6 +406,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <PrecompiledHeaderFile>Engine/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -442,6 +448,7 @@
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <PrecompiledHeaderFile>Engine/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -485,6 +492,7 @@
       <OmitFramePointers>false</OmitFramePointers>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <PrecompiledHeaderFile>Engine/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/build/vs/EngineJNI.vcxproj
+++ b/build/vs/EngineJNI.vcxproj
@@ -148,6 +148,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <OmitFramePointers>true</OmitFramePointers>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -197,6 +198,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <OmitFramePointers>true</OmitFramePointers>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -246,6 +248,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -294,6 +297,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -338,6 +342,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -384,6 +389,7 @@
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <OmitFramePointers>false</OmitFramePointers>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/build/vs/EngineLIB.vcxproj
+++ b/build/vs/EngineLIB.vcxproj
@@ -147,6 +147,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <OmitFramePointers>true</OmitFramePointers>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -196,6 +197,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
       <OmitFramePointers>true</OmitFramePointers>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -245,6 +247,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -293,6 +296,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -337,6 +341,7 @@
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -383,6 +388,7 @@
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <OmitFramePointers>false</OmitFramePointers>
       <DisableSpecificWarnings>4189</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;ECB=1;CBC=1;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/build/vs/QtBase.vcxproj
+++ b/build/vs/QtBase.vcxproj
@@ -172,6 +172,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <PrecompiledHeaderFile>QtBase/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;QT_NO_DEBUG;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -226,6 +227,7 @@ QtBase.cmd
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <PrecompiledHeaderFile>QtBase/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;QT_NO_DEBUG;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -280,6 +282,7 @@ QtBase.cmd
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <PrecompiledHeaderFile>QtBase/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;QT_NO_DEBUG;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -334,6 +337,7 @@ QtBase.cmd
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <PrecompiledHeaderFile>QtBase/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;QT_NO_DEBUG;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -387,6 +391,7 @@ QtBase.cmd
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <PrecompiledHeaderFile>QtBase/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;QT_NO_DEBUG;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -440,6 +445,7 @@ QtBase.cmd
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <PrecompiledHeaderFile>QtBase/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;QT_NO_DEBUG;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -490,6 +496,7 @@ QtBase.cmd
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DisableSpecificWarnings>4065</DisableSpecificWarnings>
       <PrecompiledHeaderFile>QtBase/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -540,6 +547,7 @@ QtBase.cmd
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <DisableSpecificWarnings>4065</DisableSpecificWarnings>
       <PrecompiledHeaderFile>QtBase/Precompiled.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_UNICODE;UNICODE;QT_BLUETOOTH_LIB;QT_CORE_LIB;QT_CONCURRENT_LIB;QT_GAMEPAD_LIB;QT_GUI_LIB;QT_MULTIMEDIA_LIB;QT_NETWORK_LIB;QT_MULTIMEDIAWIDGETS_LIB;QT_WIDGETS_LIB;QT_OPENGL_LIB;QT_PRINTSUPPORT_LIB;QT_SERIALPORT_LIB;QT_XML_LIB;NEUROMORE_ARCHITECTURE_X86;NEUROMORE_PLATFORM_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/dist/win-10/Studio.appxmanifest
+++ b/dist/win-10/Studio.appxmanifest
@@ -54,11 +54,11 @@
     <rescap:Capability Name="runFullTrust"/>
     <Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer" />
-	<DeviceCapability Name="serialcommunication">
-	  <Device Id="any">
+    <DeviceCapability Name="serialcommunication">
+      <Device Id="any">
         <Function Type="name:serialPort"/>
       </Device>
-	</DeviceCapability>
+    </DeviceCapability>
     <DeviceCapability Name="usb">
       <Device Id="any">
         <Function Type="name:vendorSpecific"/>

--- a/dist/win-10/Studio.appxmanifest
+++ b/dist/win-10/Studio.appxmanifest
@@ -51,8 +51,18 @@
   </Applications>
   
   <Capabilities>
+    <rescap:Capability Name="runFullTrust"/>
     <Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer" />
-    <rescap:Capability Name="runFullTrust"/>
-  </Capabilities> 
+	<DeviceCapability Name="serialcommunication">
+	  <Device Id="any">
+        <Function Type="name:serialPort"/>
+      </Device>
+	</DeviceCapability>
+    <DeviceCapability Name="usb">
+      <Device Id="any">
+        <Function Type="name:vendorSpecific"/>
+      </Device>
+    </DeviceCapability>
+  </Capabilities>
 </Package>

--- a/src/QtBase/Backend/WebDataCache.cpp
+++ b/src/QtBase/Backend/WebDataCache.cpp
@@ -15,34 +15,29 @@
 #include <QCryptographicHash>
 #include <QDir>
 
-
 using namespace Core;
 
 // constructor
 WebDataCache::WebDataCache(const char* subfolderPath, QObject *parent) : QObject(parent)
 {
-	mFolder = GetQtBaseManager()->GetAppDataFolder() + String(subfolderPath);
-	mFolder.ConvertToNativePath();
+   mFolder = GetQtBaseManager()->GetAppDataFolder() + String(subfolderPath);
+   mFolder.ConvertToNativePath();
 
-	// make sure the cache folder exists
-	QDir cacheDir(mFolder.AsChar());
-	if (cacheDir.mkpath(mFolder.AsChar()) == false)
-        LogError("WebDataCache: Can't create cache folder '%s'", mFolder.AsChar());
-    
-    if (cacheDir.exists() == false)
-        LogError("WebDataCache: Cache folder '%s' doesn't exist.", mFolder.AsChar());
+   // make sure the cache folder exists
+   if (!std::filesystem::exists(mFolder.AsChar()) && !std::filesystem::create_directories(mFolder.AsChar()))
+      LogError("WebDataCache: Can't create cache folder '%s'", mFolder.AsChar());
 
-	mStatusWindow					= NULL;
-	mCurrentDownload				= 0;
-	mMaxNumFails					= 4;
-	mMaxCacheRestrictionEnabled		= false;
-	mMaxCacheSizeInMb				= 1024; // 1GB default
-	mMaxAliveTimeRestrictionEnabled	= false;
-	mMaxAliveTimeInDays				= 90; // 3 months default
+   mStatusWindow                    = NULL;
+   mCurrentDownload                 = 0;
+   mMaxNumFails                     = 4;
+   mMaxCacheRestrictionEnabled      = false;
+   mMaxCacheSizeInMb                = 1024; // 1GB default
+   mMaxAliveTimeRestrictionEnabled  = false;
+   mMaxAliveTimeInDays              = 90; // 3 months default
 
 #ifndef PRODUCTION_BUILD
-	// log
-	Log();
+   // log
+   Log();
 #endif
 }
 

--- a/src/QtBase/LayoutManager.cpp
+++ b/src/QtBase/LayoutManager.cpp
@@ -58,22 +58,11 @@ String LayoutManager::GetLocalCustomLayoutsFolder() const
 {
 	QString result = GetQtBaseManager()->GetAppDataFolder().AsChar();
 	result += "Layouts";
-
-#ifdef NEUROMORE_PLATFORM_WINDOWS
-	result += "\\";
-#endif
-#ifdef NEUROMORE_PLATFORM_OSX
-    result += "/";
-#endif
-#ifdef NEUROMORE_PLATFORM_LINUX
-	result += "/";
-#endif
-
-	result = QDir::toNativeSeparators( result );
+	result += '/';
+	result = QDir::toNativeSeparators(result);
 
 	// make sure our physiological data folder exists
-	QDir appDataFolder(result);
-	appDataFolder.mkpath(result);
+	std::filesystem::create_directories(result.toStdString());
 
 	return FromQtString(result);
 }

--- a/src/QtBase/Precompiled.h
+++ b/src/QtBase/Precompiled.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// C++ Framework
+#include <filesystem>
+
 // From Engine
 #include <Engine/Core/StandardHeaders.h>
 #include <Engine/Core/String.h>

--- a/src/QtBase/QtBaseManager.cpp
+++ b/src/QtBase/QtBaseManager.cpp
@@ -173,22 +173,11 @@ bool QtBaseManager::RemoveFileFromDisk(const char* filename)
 String QtBaseManager::GetAppDataFolder()
 {
 	QString result = QStandardPaths::standardLocations(QStandardPaths::DataLocation).at(0);
-
-#ifdef NEUROMORE_PLATFORM_WINDOWS
-	result += "\\";
-#endif
-#ifdef NEUROMORE_PLATFORM_OSX
-    result += "/";
-#endif
-#ifdef NEUROMORE_PLATFORM_LINUX
 	result += "/";
-#endif
-
-	result = QDir::toNativeSeparators( result );
+	result = QDir::toNativeSeparators(result);
 
 	// make sure our folder exists
-	QDir appDataFolder(result);
-	appDataFolder.mkpath(result);
+	std::filesystem::create_directories(result.toStdString());
 
 	return FromQtString(result);
 }
@@ -198,22 +187,11 @@ void QtBaseManager::UpdatePhysiologicalDataFolder()
 {
 	QString result = GetAppDataFolder().AsChar();
 	result += "Data";
-
-#ifdef NEUROMORE_PLATFORM_WINDOWS
-	result += "\\";
-#endif
-#ifdef NEUROMORE_PLATFORM_OSX
-    result += "/";
-#endif
-#ifdef NEUROMORE_PLATFORM_LINUX
 	result += "/";
-#endif
-
-	result = QDir::toNativeSeparators( result );
+	result = QDir::toNativeSeparators(result);
 
 	// make sure our physiological data folder exists
-	QDir appDataFolder(result);
-	appDataFolder.mkpath(result);
+	std::filesystem::create_directories(result.toStdString());
 
 	mPhysiologicalDataFolder = FromQtString(result);
 }


### PR DESCRIPTION
**Changes**

* Sets Visual Studio projects to `CXX17` (same as in Make)
* Replace Qt `mkpath()` calls (buggy in restricted Win10 App) with `std::filesystem::create_directories()` (fixes non-persistence issue on Win10 app install)
* Add some basic `DeviceCapability` settings for Serial and USB to `.appxmanifest` of Studio
