### PR TITLE
neuromore staging back-end

### DIFF
--- a/src/QtBase/Backend/NetworkAccessManager.cpp
+++ b/src/QtBase/Backend/NetworkAccessManager.cpp
@@ -30,13 +30,8 @@ NetworkAccessManager::NetworkAccessManager(QObject* parent) : QObject(parent)
 	mPresets.Add(new ServerPreset("eego-perform (AWS)", "backend.eego-perform.com", "https://backend.eego-perform.com/api/", 443, "https://account.eego-perform.com"));
 	mPresets.Add(new ServerPreset("starrbase (AWS)", "backend.starrbase.myneurva.com", "https://backend.starrbase.myneurva.com/api/", 443, "https://starrbase.myneurva.com"));
 	mPresets.Add(new ServerPreset("supermind (AWS)", "backend.app.supermind.us", "https://backend.app.supermind.us/api/", 443, "https://app.supermind.us"));
-
-	// non-prod server presets (always neuromore)
-	#ifndef PRODUCTION_BUILD
-		mPresets.Add( new ServerPreset("Swap (AWS)",				"swap-prod-server.neuromore.com",	"https://swap-deployment.neuromore.com/api/",	443,	"https://account.neuromore.com") );
-		mPresets.Add( new ServerPreset("Test (AWS)",				"backend-test.neuromore.com",		"https://backend-test.neuromore.com/api/",		443,	"https://account-test.neuromore.com") );
-		mPresets.Add( new ServerPreset("localhost",					"localhost",						"http://localhost/neuromore-server/api/",		8080,	"http://localhost") );
-	#endif
+	mPresets.Add(new ServerPreset("staging (AWS)",	"backend.staging.neuromore.com",		"https://backend.staging.neuromore.com/api/",		443,	"https://account.staging.neuromore.com") );
+	mPresets.Add(new ServerPreset("localhost",		"localhost",						"http://localhost/neuromore-server/api/",		8080,	"http://localhost") );
 
 	// set default one
 	#ifdef NEUROMORE_BRANDING_ANT


### PR DESCRIPTION
* Changes old `test` backend to new `staging` backend
* Removes obsolete `swap` backend
* Makes `staging` and `localhost` backends also selectable in production builds.