### PR TITLE
Reduce Github Actions GIT LFS traffic

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019,windows-2022,macos-11,macos-12]
+        os: [windows-2022,macos-12]
         arch: [x64,x86,arm64,arm]
         branding: [neuromore]
     steps:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11,macos-12]
+        os: [macos-12]
         arch: [arm64,x64]
         branding: [neuromore]
     steps:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -59,12 +59,13 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: Repository
-        path: ./repository.tar.zst
+        path: *
 
     # Extract Repository
     - name: Extract Repository
       run: |
         ls -la
+        ls -la repository.tar.zst
         tar --zstd -xvf repository.tar.zst .
 
     # Remove Packages (20.04)

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Archive
       run: |
         touch repository.tar.zst
-        tar -I "zstd -T0 --ultra -22" --exclude=repository.tar.zst --exclude=.git -cf repository.tar.zst .
+        tar -I "zstd -T0 -19" --exclude=repository.tar.zst --exclude=.git -cf repository.tar.zst .
     - name: Upload
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -7,7 +7,34 @@ on:
       - 'master'
       - 'release'
 jobs:
+  prepare:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        token: ${{ secrets.PAT_GITHUB_ACTIONS }}
+        lfs: false
+
+    - name: Archive
+      run: tar --use-compress-program=unzstd -cvf repository.tar.zst .
+
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: Repository
+        path: ./repository.tar.zst
+
+###########################################################################
+
   build:
+    needs: prepare
     runs-on: ${{ matrix.os }}
     timeout-minutes: 360
     env:
@@ -24,6 +51,17 @@ jobs:
         arch: [amd64,i386,arm64,armhf]
         branding: [neuromore,supermind,natus]
     steps:
+
+    # Download Repository
+    - name: Download X64 Build
+      uses: actions/download-artifact@v3
+      with:
+        name: Repository
+        path: ./repository.tar.zst
+
+    # Extract Repository
+    - name: Archive
+      run: tar --use-compress-program=unzstd -xvf repository.tar.zst .
 
     # Remove Packages (20.04)
     - name: Remove Packages (20.04)
@@ -112,14 +150,6 @@ jobs:
 
     ############################################################
     
-    # Checkout
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        token: ${{ secrets.PAT_GITHUB_ACTIONS }}
-        lfs: true
-
     # Set Environment Vars
     - name: Set Environment Vars
       run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -23,7 +23,7 @@ jobs:
         lfs: false
 
     - name: Archive
-      run: tar --use-compress-program=unzstd -cvf repository.tar.zst .
+      run: tar --zstd --exclude=repository.tar.zst --exclude=.git -cvf repository.tar.zst .
 
     - name: Upload
       uses: actions/upload-artifact@v3
@@ -61,7 +61,7 @@ jobs:
 
     # Extract Repository
     - name: Archive
-      run: tar --use-compress-program=unzstd -xvf repository.tar.zst .
+      run: tar --zstd -xvf repository.tar.zst .
 
     # Remove Packages (20.04)
     - name: Remove Packages (20.04)

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         touch repository.tar.zst
         tar --zstd --exclude=repository.tar.zst --exclude=.git -cvf repository.tar.zst .
+        ls -la
 
     - name: Upload
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Archive
       run: |
         touch repository.tar.zst
-        tar --zstd --exclude=repository.tar.zst --exclude=.git -cf repository.tar.zst .
+        tar -I "zstd -T0 --ultra -22" --exclude=repository.tar.zst --exclude=.git -cf repository.tar.zst .
     - name: Upload
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -23,7 +23,7 @@ jobs:
         lfs: false
 
     - name: Archive
-      run: 
+      run: |
         touch repository.tar.zst
         tar --zstd --exclude=repository.tar.zst --exclude=.git -cvf repository.tar.zst .
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -55,15 +55,17 @@ jobs:
     steps:
 
     # Download Repository
-    - name: Download X64 Build
+    - name: Download Repository
       uses: actions/download-artifact@v3
       with:
         name: Repository
         path: ./repository.tar.zst
 
     # Extract Repository
-    - name: Archive
-      run: tar --zstd -xvf repository.tar.zst .
+    - name: Extract Repository
+      run: |
+        ls -la
+        tar --zstd -xvf repository.tar.zst .
 
     # Remove Packages (20.04)
     - name: Remove Packages (20.04)

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -23,7 +23,9 @@ jobs:
         lfs: false
 
     - name: Archive
-      run: tar --zstd --exclude=repository.tar.zst --exclude=.git -cvf repository.tar.zst .
+      run: 
+        touch repository.tar.zst
+        tar --zstd --exclude=repository.tar.zst --exclude=.git -cvf repository.tar.zst .
 
     - name: Upload
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -7,6 +7,7 @@ on:
       - 'master'
       - 'release'
 jobs:
+###########################################################################
   prepare:
     runs-on: ubuntu-22.04
     timeout-minutes: 360
@@ -21,13 +22,10 @@ jobs:
         submodules: recursive
         token: ${{ secrets.PAT_GITHUB_ACTIONS }}
         lfs: false
-
     - name: Archive
       run: |
         touch repository.tar.zst
-        tar --zstd --exclude=repository.tar.zst --exclude=.git -cvf repository.tar.zst .
-        ls -la
-
+        tar --zstd --exclude=repository.tar.zst --exclude=.git -cf repository.tar.zst .
     - name: Upload
       uses: actions/upload-artifact@v3
       with:
@@ -35,7 +33,6 @@ jobs:
         path: ./repository.tar.zst
 
 ###########################################################################
-
   build:
     needs: prepare
     runs-on: ${{ matrix.os }}
@@ -65,9 +62,7 @@ jobs:
     # Extract Repository
     - name: Extract Repository
       run: |
-        ls -la
-        ls -la repository.tar.zst
-        tar --zstd -xvf repository.tar.zst .
+        tar --zstd -xf repository.tar.zst .
 
     # Remove Packages (20.04)
     - name: Remove Packages (20.04)

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Upload
       uses: actions/upload-artifact@v3
       with:
+        retention-days: 1
         name: Repository
         path: ./repository.tar.zst
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Archive
       run: |
         touch repository.tar.zst
-        tar -I "zstd -T0 -19" --exclude=repository.tar.zst --exclude=.git -cf repository.tar.zst .
+        tar -I "zstd -T0 --ultra -10" --exclude=repository.tar.zst --exclude=.git -cf repository.tar.zst .
     - name: Upload
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: Repository
-        path: *
+        path: .
 
     # Extract Repository
     - name: Extract Repository

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         submodules: recursive
         token: ${{ secrets.PAT_GITHUB_ACTIONS }}
-        lfs: false
+        lfs: true
     - name: Archive
       run: |
         touch repository.tar.zst

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11,macos-12]
+        os: [macos-12]
         branding: [neuromore,supermind,natus]
     env:
       BRANDING: ${{ matrix.branding }}
@@ -204,7 +204,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11,macos-12]
+        os: [macos-12]
         branding: [neuromore]
     env:
       BRANDING: ${{ matrix.branding }}

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -142,28 +142,28 @@ jobs:
 
     # Download X64 Build
     - name: Download X64 Build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: Binaries (${{ matrix.os }}-x64-${{ matrix.branding }})
         path: ./build/make/bin/osx-x64/
 
     # Download X64 lto.o
     - name: Download X64 lto.o
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: lto.o (${{ matrix.os }}-x64-${{ matrix.branding }})
         path: ./build/make/obj/osx-x64-release/
 
     # Download ARM64 Build
     - name: Download ARM64 Build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: Binaries (${{ matrix.os }}-arm64-${{ matrix.branding }})
         path: ./build/make/bin/osx-arm64/
 
     # Download ARM64 lto.o
     - name: Download ARM64 lto.o
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: lto.o (${{ matrix.os }}-arm64-${{ matrix.branding }})
         path: ./build/make/obj/osx-arm64-release/

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -143,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019,windows-2022]
+        os: [windows-2022]
         branding: [neuromore,supermind,natus]
     env:
       BRANDING: ${{ matrix.branding }}


### PR DESCRIPTION
* Does not run Android CI pipeline on `macos-11` and `windows-2019` anymore
* Does not run iOS CI pipeline on `macos-11` anymore
* Does not create packages on `windows-2019` and `macos-11` anymore
* Updates `download-artifact` action to `v3` in macOS CI pipeline
* Checks out the repository once with GIT LFS in Linux CI and reuse it as artifact
