### PR TITLE
Fix CSV Reader and fix some first zero case

### DIFF
--- a/src/Engine/DSP/ResampleProcessor.cpp
+++ b/src/Engine/DSP/ResampleProcessor.cpp
@@ -438,13 +438,14 @@ void ResampleProcessor::DoOutputLast()
 {
 	// new samples we have to output
 	const uint32 numNewSamples = mOutputClock.GetNumNewTicks();
-	mOutputClock.ClearNewTicks();
 
 	ChannelBase* input = GetInput();
 	Channel<double>* output = GetOutput()->AsType<double>();
 
 	if (input != NULL && input->IsEmpty() == false)
 	{
+		mOutputClock.ClearNewTicks();
+
 		// get the last value
 		double lastValue = input->AsType<double>()->GetLastSample();
 

--- a/src/Engine/DSP/ResampleProcessor.cpp
+++ b/src/Engine/DSP/ResampleProcessor.cpp
@@ -442,18 +442,19 @@ void ResampleProcessor::DoOutputLast()
 
 	ChannelBase* input = GetInput();
 	Channel<double>* output = GetOutput()->AsType<double>();
-	
-	// get the last value
-	double lastValue = 0;
+
 	if (input != NULL && input->IsEmpty() == false)
-		lastValue = input->AsType<double>()->GetLastSample();
+	{
+		// get the last value
+		double lastValue = input->AsType<double>()->GetLastSample();
 
-	// output the required number of samples
-	for (uint32 i = 0; i < numNewSamples; i++)
-		output->AddSample(lastValue);
+		// output the required number of samples
+		for (uint32 i = 0; i < numNewSamples; i++)
+			output->AddSample(lastValue);
 
-	// flush input reader (not used here)
-	GetInputReader()->Flush();
+		// flush input reader (not used here)
+		GetInputReader()->Flush();
+	}
 }
 
 

--- a/src/Engine/Sensor.cpp
+++ b/src/Engine/Sensor.cpp
@@ -191,11 +191,14 @@ void Sensor::SetSampleRate(double sampleRate)
 {
 	mSampleRate = sampleRate;
 
+	// set samplerate on input and output
+	// the resampler evaluates this
+	GetOutput()->SetSampleRate(mSampleRate);
+	GetInput()->SetSampleRate(mSampleRate);
+
 	// set sample rate of resampler
 	mResampler.SetOutputSampleRate(mSampleRate);
 	mResampler.ReInit();
-	
-	GetOutput()->SetSampleRate(mSampleRate);
 }
 
 


### PR DESCRIPTION
* Stop adding `0.0` if no last sample is available in `DoOutputLast()` in `ResampleProcessor.cpp`. Instead skip until a last sample is available (e.g. next tick).
* Also call `SetSampleRate()` for Input Port in `Sensor.cpp` as this is evaluated by `ResampleProcessor` and by default leads to DoOutputLast() if not set (and to resampling if not set identically)
  * This fixes CSV values not correctly read (a single one was repeated many times)