### PR TITLE
Improve Channel Checkboxes Preselection

### DIFF
--- a/src/Engine/Branding.h
+++ b/src/Engine/Branding.h
@@ -56,6 +56,7 @@ public:
    static constexpr const bool  DefaultEemagineEnabled      = true;
    static constexpr const bool  DefaultBrainMasterEnabled   = false;
    static constexpr const int   DefaultServerPresetIdx      = 0;
+   static constexpr const int   DefaultAutoSelectType       = 0; // = ALL (see ChannelMultiSelectionWidget.h)
 };
 #endif
 #endif

--- a/src/Studio/Plugins/RawWaveform/RawWaveformPlugin.cpp
+++ b/src/Studio/Plugins/RawWaveform/RawWaveformPlugin.cpp
@@ -62,7 +62,7 @@ bool RawWaveformPlugin::Init()
 
 	// init checkbox widget
 	mChannelSelectionWidget = new ChannelMultiSelectionWidget();
-	mChannelSelectionWidget->SetAutoSelectType(ChannelMultiSelectionWidget::AutoSelectType::SELECT_ALL);
+	mChannelSelectionWidget->SetAutoSelectType((ChannelMultiSelectionWidget::AutoSelectType)Branding::DefaultAutoSelectType);
 	mChannelSelectionWidget->SetShowNeuroChannelsOnly(true);
 	mChannelSelectionWidget->Init();
 	connect( mChannelSelectionWidget, SIGNAL(ShowUsedCheckboxToggled(int)), this, SLOT(OnShowUsedCheckboxToggled(int)) );

--- a/src/Studio/Plugins/Spectrogram2D/Spectrogram2DPlugin.cpp
+++ b/src/Studio/Plugins/Spectrogram2D/Spectrogram2DPlugin.cpp
@@ -113,7 +113,7 @@ bool Spectrogram2DPlugin::Init()
 	mChannelSelectionWidget = new ChannelMultiSelectionWidget(mainWidget);
 	toolbarWidgets.Add(mChannelSelectionWidget);
 	connect(mChannelSelectionWidget, SIGNAL(ChannelSelectionChanged()), this, SLOT(OnChannelSelectionChanged()));
-	mChannelSelectionWidget->SetAutoSelectType(ChannelMultiSelectionWidget::AutoSelectType::SELECT_ALL);
+	mChannelSelectionWidget->SetAutoSelectType((ChannelMultiSelectionWidget::AutoSelectType)Branding::DefaultAutoSelectType);
 	mChannelSelectionWidget->SetShowNeuroChannelsOnly(true);
 	mChannelSelectionWidget->Init();
 

--- a/src/Studio/Widgets/ChannelMultiSelectionWidget.cpp
+++ b/src/Studio/Widgets/ChannelMultiSelectionWidget.cpp
@@ -165,7 +165,8 @@ void ChannelMultiSelectionWidget::ReInit(Device* device)
 	{
 		case AutoSelectType::SELECT_NONE: numBoxesToSelect = 0; break;
 		case AutoSelectType::SELECT_FIRST: numBoxesToSelect = 1; break;
-		
+		case AutoSelectType::SELECT_FIRST_TWO: numBoxesToSelect = 2; break;
+
 		case AutoSelectType::SELECT_ALL: 
 		default:
 			numBoxesToSelect = numCheckBoxes; break;

--- a/src/Studio/Widgets/ChannelMultiSelectionWidget.h
+++ b/src/Studio/Widgets/ChannelMultiSelectionWidget.h
@@ -36,11 +36,12 @@ class ChannelMultiSelectionWidget : public QWidget
 {
 	Q_OBJECT
 	public:
-		// device-change behaviour
+		// device-change behaviour (values used in Branding.h!)
 		enum AutoSelectType { 
-			SELECT_NONE, 
-			SELECT_FIRST, 
-			SELECT_ALL 
+			SELECT_ALL       = 0,
+			SELECT_NONE      = 1,
+			SELECT_FIRST     = 2,
+			SELECT_FIRST_TWO = 3
 		};
 
 		// constructor & destructor


### PR DESCRIPTION
Adds `SELECT_FIRST_TWO` as new `AutoSelectType` option and loads used value from branding constants.