### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022,macos-12]
+        os: [windows-2022]
         arch: [x64,x86,arm64,arm]
         branding: [neuromore]
     steps:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -91,6 +91,7 @@ jobs:
     # Ubuntu Update
     - name: Update Ubuntu
       run: |
+        sudo update-grub
         sudo apt-get update -y 
         sudo apt-get upgrade -f -y
         sudo apt-get dist-upgrade -f -y

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -91,6 +91,7 @@ jobs:
     # Ubuntu Update
     - name: Update Ubuntu
       run: |
+        sudo apt-get install grub-efi-amd64-bin
         sudo update-grub
         sudo apt-get update -y 
         sudo apt-get upgrade -f -y

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -90,12 +90,7 @@ jobs:
 
     # Ubuntu Update
     - name: Update Ubuntu
-      run: |
-        sudo apt-get install grub-efi-amd64-bin
-        sudo update-grub
-        sudo apt-get update -y 
-        sudo apt-get upgrade -f -y
-        sudo apt-get dist-upgrade -f -y
+      run: sudo apt-get update -y 
 
     # Ubuntu Version
     - name: Ubuntu Version

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11,macos-12]
+        os: [macos-12]
         arch: [x64,arm64]
         branding: [neuromore,supermind,natus]
     steps:

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019,windows-2022]
+        os: [windows-2022]
         arch: [x64,x86,arm64]
         branding: [neuromore,supermind,natus]
     steps:


### PR DESCRIPTION
* Disable `windows-2019` Builds
* Disable `macos-11` Builds
* Disable Android Builds on `macos-12`
* Don't upgrade Ubuntu anymore as part of the CI steps (fix latest CI error on Ubuntu 20.04)