### PR TITLE
Fix Qt Bluetooth LE Crash on macOS

### DIFF
--- a/deps/src/qt-bluetooth/osx/osxbtconnectionmonitor.mm
+++ b/deps/src/qt-bluetooth/osx/osxbtconnectionmonitor.mm
@@ -81,13 +81,8 @@ using namespace QT_NAMESPACE;
 
 - (void)dealloc
 {
-    [discoveryNotification unregister];
-    [discoveryNotification release];
-
-    for (IOBluetoothUserNotification *n in foundConnections)
-        [n unregister];
-
-    [foundConnections release];
+    Q_ASSERT_X(!monitor, "-dealloc",
+               "Connection monitor was not stopped, calling -stopMonitoring is required");
 
     [super dealloc];
 }
@@ -135,6 +130,20 @@ using namespace QT_NAMESPACE;
 
     Q_ASSERT_X(monitor, "-connectionClosedNotification:withDevice:", "invalid monitor (null)");
     monitor->deviceDisconnected(deviceAddress);
+}
+
+- (void)stopMonitoring
+{
+    monitor = nullptr;
+    [discoveryNotification unregister];
+    [discoveryNotification release];
+    discoveryNotification = nil;
+
+    for (IOBluetoothUserNotification *n in foundConnections)
+        [n unregister];
+
+    [foundConnections release];
+    foundConnections = nil;
 }
 
 @end

--- a/deps/src/qt-bluetooth/osx/osxbtconnectionmonitor_p.h
+++ b/deps/src/qt-bluetooth/osx/osxbtconnectionmonitor_p.h
@@ -84,6 +84,8 @@ QT_END_NAMESPACE
 - (void)connectionNotification:(id)notification withDevice:(IOBluetoothDevice *)device;
 - (void)connectionClosedNotification:(id)notification withDevice:(IOBluetoothDevice *)device;
 
+- (void)stopMonitoring;
+
 @end
 
 #endif

--- a/deps/src/qt-bluetooth/qbluetoothlocaldevice_osx.mm
+++ b/deps/src/qt-bluetooth/qbluetoothlocaldevice_osx.mm
@@ -66,6 +66,7 @@ public:
 
     QBluetoothLocalDevicePrivate(QBluetoothLocalDevice *, const QBluetoothAddress & =
                                  QBluetoothAddress());
+    ~QBluetoothLocalDevicePrivate();
 
     bool isValid() const;
     void requestPairing(const QBluetoothAddress &address, Pairing pairing);
@@ -145,6 +146,11 @@ QBluetoothLocalDevicePrivate::QBluetoothLocalDevicePrivate(QBluetoothLocalDevice
 
     // This one is optional, if it fails to initialize, we do not care at all.
     connectionMonitor.reset([[ObjCConnectionMonitor alloc] initWithMonitor:this]);
+}
+
+QBluetoothLocalDevicePrivate::~QBluetoothLocalDevicePrivate()
+{
+    [connectionMonitor stopMonitoring];
 }
 
 bool QBluetoothLocalDevicePrivate::isValid() const


### PR DESCRIPTION
* Fixes crash on macOS when trying to connect to a HRM and Bluetooth permissions were already granted
* Ported from [official commit](https://github.com/qt/qtconnectivity/commit/bd1671ac91afafcd446e305cdb303838937eb332)