### PR TITLE
RawEEG: GridLayout for Electrode CheckBoxes

### DIFF
--- a/src/Engine/Branding.h
+++ b/src/Engine/Branding.h
@@ -56,7 +56,7 @@ public:
    static constexpr const bool  DefaultEemagineEnabled      = true;
    static constexpr const bool  DefaultBrainMasterEnabled   = false;
    static constexpr const int   DefaultServerPresetIdx      = 0;
-   static constexpr const int   DefaultAutoSelectType       = 0; // = ALL (see ChannelMultiSelectionWidget.h)
+   static constexpr const int   DefaultAutoSelectType       = 4; // = SELECT_FIRST_EIGHT (see ChannelMultiSelectionWidget.h)
 };
 #endif
 #endif

--- a/src/Studio/Widgets/ChannelMultiSelectionWidget.cpp
+++ b/src/Studio/Widgets/ChannelMultiSelectionWidget.cpp
@@ -46,7 +46,7 @@ ChannelMultiSelectionWidget::ChannelMultiSelectionWidget(QWidget* parent) : QWid
 
 	QHBoxLayout* hLayout = new QHBoxLayout();
 	hLayout->addWidget(mDeviceSelectionWidget, 0, Qt::AlignTop);
-	hLayout->addWidget(mShowUsedCheckbox);
+	hLayout->addWidget(mShowUsedCheckbox, 0, Qt::AlignTop);
 	hLayout->addWidget(mChannelMultiCheckbox);
 	hLayout->setMargin(0);
 	hLayout->setSpacing(0);

--- a/src/Studio/Widgets/ChannelMultiSelectionWidget.cpp
+++ b/src/Studio/Widgets/ChannelMultiSelectionWidget.cpp
@@ -166,6 +166,7 @@ void ChannelMultiSelectionWidget::ReInit(Device* device)
 		case AutoSelectType::SELECT_NONE: numBoxesToSelect = 0; break;
 		case AutoSelectType::SELECT_FIRST: numBoxesToSelect = 1; break;
 		case AutoSelectType::SELECT_FIRST_TWO: numBoxesToSelect = 2; break;
+		case AutoSelectType::SELECT_FIRST_EIGHT: numBoxesToSelect = 8; break;
 
 		case AutoSelectType::SELECT_ALL: 
 		default:

--- a/src/Studio/Widgets/ChannelMultiSelectionWidget.cpp
+++ b/src/Studio/Widgets/ChannelMultiSelectionWidget.cpp
@@ -45,7 +45,7 @@ ChannelMultiSelectionWidget::ChannelMultiSelectionWidget(QWidget* parent) : QWid
 	connect(mDeviceSelectionWidget, SIGNAL(DeviceSelectionChanged(Device*)), this, SLOT(OnDeviceSelectionChanged(Device*)));
 
 	QHBoxLayout* hLayout = new QHBoxLayout();
-	hLayout->addWidget(mDeviceSelectionWidget);
+	hLayout->addWidget(mDeviceSelectionWidget, 0, Qt::AlignTop);
 	hLayout->addWidget(mShowUsedCheckbox);
 	hLayout->addWidget(mChannelMultiCheckbox);
 	hLayout->setMargin(0);

--- a/src/Studio/Widgets/ChannelMultiSelectionWidget.h
+++ b/src/Studio/Widgets/ChannelMultiSelectionWidget.h
@@ -38,10 +38,11 @@ class ChannelMultiSelectionWidget : public QWidget
 	public:
 		// device-change behaviour (values used in Branding.h!)
 		enum AutoSelectType { 
-			SELECT_ALL       = 0,
-			SELECT_NONE      = 1,
-			SELECT_FIRST     = 2,
-			SELECT_FIRST_TWO = 3
+			SELECT_ALL         = 0,
+			SELECT_NONE        = 1,
+			SELECT_FIRST       = 2,
+			SELECT_FIRST_TWO   = 3,
+			SELECT_FIRST_EIGHT = 4,
 		};
 
 		// constructor & destructor

--- a/src/Studio/Widgets/HMultiCheckboxWidget.cpp
+++ b/src/Studio/Widgets/HMultiCheckboxWidget.cpp
@@ -88,14 +88,19 @@ void HMultiCheckboxWidget::ReInit(const Array<String>& names, const Array<String
 	// prepare the checkbox array
 	mCheckboxes.Resize( numCheckboxes );
 
-	int col = 1;
-	int row = 0;
+	// break line after that many checkboxes
+	const uint32_t BOXESINROW = 16;
+
+	// start cell (all is in 0,0)
+	uint32_t row = 0;
+	uint32_t col = 1;
 
 	// iterate through the available checkboxes
 	Core::String widgetColorText;
 	for (uint32 i=0; i<numCheckboxes; ++i)
 	{
-		if (i != 0 && i % 5 == 0) {
+		// flow to next row
+		if (i != 0 && i % BOXESINROW == 0) {
 			row++;
 			col = 1;
 		}

--- a/src/Studio/Widgets/HMultiCheckboxWidget.cpp
+++ b/src/Studio/Widgets/HMultiCheckboxWidget.cpp
@@ -66,7 +66,7 @@ void HMultiCheckboxWidget::ReInit(const Array<String>& names, const Array<String
 	CORE_ASSERT( numCheckboxes == tooltips.Size() && numCheckboxes == colors.Size() );
 
 	// layout for the checkboxes
-	QHBoxLayout* hLayout = new QHBoxLayout();
+	QGridLayout* hLayout = new QGridLayout();
 	hLayout->setMargin(3);
 	hLayout->setSpacing(10);
 	hLayout->setAlignment( Qt::AlignLeft );
@@ -78,7 +78,7 @@ void HMultiCheckboxWidget::ReInit(const Array<String>& names, const Array<String
 		mCheckboxAll = new QCheckBox( allCheckboxName );
 		mCheckboxAll->setToolTip( "Enable/disable all with a single click" );
 		mCheckboxAll->setChecked( true );
-		hLayout->addWidget( mCheckboxAll );
+		hLayout->addWidget( mCheckboxAll, 0, 0 );
 		connect( mCheckboxAll, SIGNAL(stateChanged(int)), this, SLOT(OnAllCheckbox(int)) );
 	} else
 	{
@@ -88,10 +88,18 @@ void HMultiCheckboxWidget::ReInit(const Array<String>& names, const Array<String
 	// prepare the checkbox array
 	mCheckboxes.Resize( numCheckboxes );
 
+	int col = 1;
+	int row = 0;
+
 	// iterate through the available checkboxes
 	Core::String widgetColorText;
 	for (uint32 i=0; i<numCheckboxes; ++i)
 	{
+		if (i != 0 && i % 5 == 0) {
+			row++;
+			col = 1;
+		}
+
 		// create the style sheet used to set the checkbox's color
 		widgetColorText.Format( "QCheckBox { color: rgb(%.0f, %.0f, %.0f) }", colors[i].r*255.0f, colors[i].g*255.0f, colors[i].b*255.0f );
 
@@ -103,7 +111,8 @@ void HMultiCheckboxWidget::ReInit(const Array<String>& names, const Array<String
 
 		// connect and add it
 		connect( mCheckboxes[i], SIGNAL(stateChanged(int)), this, SLOT(OnCheckbox(int)) );
-		hLayout->addWidget( mCheckboxes[i] );
+		hLayout->addWidget( mCheckboxes[i], row, col );
+		col++;
 	}
 
 	mMainWidget->setLayout(hLayout);

--- a/src/Studio/Widgets/HMultiCheckboxWidget.cpp
+++ b/src/Studio/Widgets/HMultiCheckboxWidget.cpp
@@ -89,7 +89,7 @@ void HMultiCheckboxWidget::ReInit(const Array<String>& names, const Array<String
 	mCheckboxes.Resize( numCheckboxes );
 
 	// break line after that many checkboxes
-	const uint32_t BOXESINROW = 16;
+	const uint32_t BOXESINROW = 8;
 
 	// start cell (all is in 0,0)
 	uint32_t row = 0;

--- a/src/Studio/Widgets/HMultiCheckboxWidget.h
+++ b/src/Studio/Widgets/HMultiCheckboxWidget.h
@@ -30,6 +30,7 @@
 #include <Core/Color.h>
 #include <QWidget>
 #include <QVBoxLayout>
+#include <QGridLayout>
 #include <QCheckBox>
 
 


### PR DESCRIPTION
* RawEEG: Replaces infinitely growing `QHBoxLayout` for EEG Electrodes by `QGridLayout` with 8 columns
* RawEEG: Only select/show first 8 electrodes by default.