### PR TITLE
Misc. Fixes

### DIFF
--- a/deps/include/qt/QtBluetooth/private/qlowenergycontroller_winrt_p.h
+++ b/deps/include/qt/QtBluetooth/private/qlowenergycontroller_winrt_p.h
@@ -133,6 +133,7 @@ private:
         EventRegistrationToken token;
     };
     QVector<ValueChangedEntry> mValueChangedTokens;
+    std::map<QBluetoothUuid, Microsoft::WRL::ComPtr<ABI::Windows::Devices::Bluetooth::GenericAttributeProfile::IGattDeviceService>> m_openedServices;
 
     Microsoft::WRL::ComPtr<ABI::Windows::Devices::Bluetooth::GenericAttributeProfile::IGattDeviceService> getNativeService(const QBluetoothUuid &serviceUuid);
     Microsoft::WRL::ComPtr<ABI::Windows::Devices::Bluetooth::GenericAttributeProfile::IGattCharacteristic> getNativeCharacteristic(const QBluetoothUuid &serviceUuid, const QBluetoothUuid &charUuid);
@@ -142,6 +143,8 @@ private:
     void obtainIncludedServices(QSharedPointer<QLowEnergyServicePrivate> servicePointer,
         Microsoft::WRL::ComPtr<ABI::Windows::Devices::Bluetooth::GenericAttributeProfile::IGattDeviceService> nativeService);
 
+    void clearAllServices();
+    void closeAndRemoveService(const QBluetoothUuid& uuid);
 };
 
 QT_END_NAMESPACE

--- a/deps/src/qt-bluetooth/qbluetoothdevicediscoveryagent_winrt.cpp
+++ b/deps/src/qt-bluetooth/qbluetoothdevicediscoveryagent_winrt.cpp
@@ -607,10 +607,8 @@ void QBluetoothDeviceDiscoveryAgentPrivate::stop()
         disconnectAndClearWorker();
         emit q->canceled();
     }
-    if (leScanTimer) {
+    if (leScanTimer)
         leScanTimer->stop();
-        worker->deleteLater();
-    }
 }
 
 void QBluetoothDeviceDiscoveryAgentPrivate::registerDevice(const QBluetoothDeviceInfo &info)

--- a/deps/src/qt-bluetooth/qbluetoothdevicediscoveryagent_winrt.cpp
+++ b/deps/src/qt-bluetooth/qbluetoothdevicediscoveryagent_winrt.cpp
@@ -84,7 +84,7 @@ public:
     explicit QWinRTBluetoothDeviceDiscoveryWorker(QBluetoothDeviceDiscoveryAgent::DiscoveryMethods methods);
     ~QWinRTBluetoothDeviceDiscoveryWorker();
     void start();
-    void stop();
+    void stopLEWatcher();
 
 private:
     void startDeviceDiscovery(QBluetoothDeviceDiscoveryAgent::DiscoveryMethod mode);
@@ -144,7 +144,7 @@ QWinRTBluetoothDeviceDiscoveryWorker::QWinRTBluetoothDeviceDiscoveryWorker(QBlue
 
 QWinRTBluetoothDeviceDiscoveryWorker::~QWinRTBluetoothDeviceDiscoveryWorker()
 {
-    stop();
+    stopLEWatcher();
 #ifdef CLASSIC_APP_BUILD
     CoUninitialize();
 #endif
@@ -166,7 +166,7 @@ void QWinRTBluetoothDeviceDiscoveryWorker::start()
     qCDebug(QT_BT_WINRT) << "Worker started";
 }
 
-void QWinRTBluetoothDeviceDiscoveryWorker::stop()
+void QWinRTBluetoothDeviceDiscoveryWorker::stopLEWatcher()
 {
     if (m_leWatcher) {
         HRESULT hr = m_leWatcher->Stop();
@@ -269,6 +269,7 @@ void QWinRTBluetoothDeviceDiscoveryWorker::setupLEDeviceWatcher()
 void QWinRTBluetoothDeviceDiscoveryWorker::finishDiscovery()
 {
     emit scanFinished();
+    stopLEWatcher();
     deleteLater();
 }
 
@@ -602,7 +603,7 @@ void QBluetoothDeviceDiscoveryAgentPrivate::stop()
 {
     Q_Q(QBluetoothDeviceDiscoveryAgent);
     if (worker) {
-        worker->stop();
+        worker->stopLEWatcher();
         disconnectAndClearWorker();
         emit q->canceled();
     }

--- a/src/Studio/Devices/Bluetooth/BluetoothDevice.h
+++ b/src/Studio/Devices/Bluetooth/BluetoothDevice.h
@@ -53,7 +53,7 @@ class BluetoothDevice : public QObject
         bool IsConnected() const                                            { return mIsConnected; }
     
     signals:
-        void Finished();
+        void Finished(BluetoothDevice* device);
 
 	private slots:
 		void OnServiceDiscovered(const QBluetoothUuid& gatt);

--- a/src/Studio/Devices/Bluetooth/BluetoothDriver.h
+++ b/src/Studio/Devices/Bluetooth/BluetoothDriver.h
@@ -81,6 +81,7 @@ class BluetoothDriver : public QObject, public DeviceDriver, public Core::EventH
 		void OnDeviceScanFinished();
 		void OnDeviceDiscovered(const QBluetoothDeviceInfo& deviceInfo);
 		void OnDeviceScanError(QBluetoothDeviceDiscoveryAgent::Error error);
+		void OnDeviceScanCanceled();
 
         //void OnConnectNextDevice();
 void Connect(const QBluetoothDeviceInfo& deviceInfo);

--- a/src/Studio/Devices/Bluetooth/BluetoothDriver.h
+++ b/src/Studio/Devices/Bluetooth/BluetoothDriver.h
@@ -93,7 +93,7 @@ void Connect(const QBluetoothDeviceInfo& deviceInfo);
 	private:
 		// device discovery
 		QTimer*								mAutodetectTimer;
-		bool								mDetectOnce;
+		bool								mIsBtleSupported;
 		bool								mIsSearching;
 		QBluetoothDeviceDiscoveryAgent*		mBluetoothDeviceDiscoveryAgent;
 		Core::Array<QBluetoothDeviceInfo>	mDiscoveredDeviceInfos;

--- a/src/Studio/Devices/Bluetooth/BluetoothDriver.h
+++ b/src/Studio/Devices/Bluetooth/BluetoothDriver.h
@@ -76,6 +76,7 @@ class BluetoothDriver : public QObject, public DeviceDriver, public Core::EventH
 	private slots:
 		// autodetect timer
 		void OnDetectDevices();
+		void OnDeviceFinished(BluetoothDevice* device);
 
 		// Bluetooth device discovery agent slots
 		void OnDeviceScanFinished();

--- a/src/Studio/Devices/BrainFlow/BrainFlowDriver.cpp
+++ b/src/Studio/Devices/BrainFlow/BrainFlowDriver.cpp
@@ -40,7 +40,9 @@ BrainFlowDriver::BrainFlowDriver() : DeviceDriver(true)
 }
 
 void BrainFlowDriver::DetectDevices() {
-	SetEnabled();
+	if (!mIsEnabled)
+		return;
+
 	if (auto* device = GetDeviceManager()->FindDeviceByType(BrainFlowDevice::TYPE_ID, 0))
 	{
 		GetDeviceManager()->RemoveDeviceAsync(device);


### PR DESCRIPTION
* Stop automatically enabling Brainflow driver whenever starting a device search even when it was disabled
* Backported some Qt fixes for BTLE on Windows
  * [1](https://github.com/qt/qtconnectivity/commit/ed4f9f3c4354d4f65318832eadaf0cfc5c288404)
  * [2](https://github.com/qt/qtconnectivity/commit/4ac755bb6e51891881b7477702be8ca917b60c8a)
  * [3](https://codereview.qt-project.org/c/qt/qtconnectivity/+/392128)
* Make Auto-Detection work fine again with BTLE (at least on macOS)
* Filter for HRM and only show device popup if more than one HRM found
* Improve BTLE logging for HRM
* Check for BTLE support on Bluetooth device before doing anything BTLE like with it