### PR TITLE
Decouple Engine Reset and Session Start

### DIFF
--- a/src/Engine/Core/EventHandler.h
+++ b/src/Engine/Core/EventHandler.h
@@ -68,6 +68,7 @@ class ENGINE_API EventHandler
 
 		// session
 		virtual void OnPrepareSession()							{}
+		virtual void OnPreparedSession()						{}
 		virtual void OnStartSession()							{}
 		virtual void OnStopSession()							{}
 		virtual void OnSessionUserChanged(const User& user)		{}

--- a/src/Engine/Core/EventHandler.h
+++ b/src/Engine/Core/EventHandler.h
@@ -67,6 +67,7 @@ class ENGINE_API EventHandler
 		virtual void OnSubProgressValue( float percentage )		{}
 
 		// session
+		virtual void OnPrepareSession()							{}
 		virtual void OnStartSession()							{}
 		virtual void OnStopSession()							{}
 		virtual void OnSessionUserChanged(const User& user)		{}

--- a/src/Engine/Core/EventManager.h
+++ b/src/Engine/Core/EventManager.h
@@ -91,6 +91,7 @@ class ENGINE_API EventManager
 		inline EVENT_CREATE_NOTIFY_FUNCTION_1( OnSubProgressValue, float, percentage );
 
 		// session
+		inline EVENT_CREATE_NOTIFY_FUNCTION_0( OnPrepareSession );
 		inline EVENT_CREATE_NOTIFY_FUNCTION_0( OnStartSession );
 		inline EVENT_CREATE_NOTIFY_FUNCTION_0( OnStopSession );
 		inline EVENT_CREATE_NOTIFY_FUNCTION_1( OnSessionUserChanged, const User&, user );

--- a/src/Engine/Core/EventManager.h
+++ b/src/Engine/Core/EventManager.h
@@ -92,6 +92,7 @@ class ENGINE_API EventManager
 
 		// session
 		inline EVENT_CREATE_NOTIFY_FUNCTION_0( OnPrepareSession );
+		inline EVENT_CREATE_NOTIFY_FUNCTION_0( OnPreparedSession );
 		inline EVENT_CREATE_NOTIFY_FUNCTION_0( OnStartSession );
 		inline EVENT_CREATE_NOTIFY_FUNCTION_0( OnStopSession );
 		inline EVENT_CREATE_NOTIFY_FUNCTION_1( OnSessionUserChanged, const User&, user );

--- a/src/Engine/EngineManager.cpp
+++ b/src/Engine/EngineManager.cpp
@@ -197,7 +197,7 @@ void EngineManager::Update(Time delta)
 	const double timeDelta = delta.InSeconds();
 
 	// 1) update the session first (because of session state and time elapsed)
-	mSession->Update(timeDelta);
+	mSession->Update(mElapsedTime, timeDelta);
 
 	// 2) update the osc message router, so the newest messages are pushed into the devices
 	// this internally passes the asynch received messages over to the receiver objects and let them process the data

--- a/src/Engine/Graph/Classifier.cpp
+++ b/src/Engine/Graph/Classifier.cpp
@@ -109,6 +109,18 @@ void Classifier::Reset()
 	Graph::Reset();
 }
 
+void Classifier::ResetOnSessionStart()
+{
+	uint32 num;
+
+	// reset some nodes
+	num = GetNumNodes();
+	for (uint32_t i = 0; i < num; i++) {
+		Node* n = GetNode(i);
+		if (n->GetType() == FileWriterNode::TYPE_ID || n->GetNodeType() == OutputNode::NODE_TYPE)
+			n->Reset();
+	}
+}
 
 // force reinit during next update
 void Classifier::ReInitAsync()

--- a/src/Engine/Graph/Classifier.cpp
+++ b/src/Engine/Graph/Classifier.cpp
@@ -59,6 +59,17 @@ Classifier::~Classifier()
 }
 
 
+void Classifier::Init()
+{
+	Graph::Init();
+
+	Core::AttributeSettings* attribInitTime = RegisterAttribute("Init Time (s)", "InitTime", "Required initialization time until classifier is stable.", Core::ATTRIBUTE_INTERFACETYPE_FLOATSPINNER);
+	attribInitTime->SetDefaultValue(Core::AttributeFloat::Create(DEFAULTINITTIME));
+	attribInitTime->SetMinValue(Core::AttributeFloat::Create(0.0));
+	attribInitTime->SetMaxValue(Core::AttributeFloat::Create(30.0));
+}
+
+
 // update the graph
 void Classifier::Update(const Time& elapsed, const Time& delta)
 {

--- a/src/Engine/Graph/Classifier.cpp
+++ b/src/Engine/Graph/Classifier.cpp
@@ -122,11 +122,14 @@ void Classifier::Reset()
 
 void Classifier::ResetOnSessionStart()
 {
+	uint32 num;
+
 	// reset some nodes
-	const uint32 num = GetNumOutputNodes();
+	num = GetNumNodes();
 	for (uint32_t i = 0; i < num; i++) {
-		OutputNode* n = GetOutputNode(i);
-		n->Reset();
+		Node* n = GetNode(i);
+		if (n->GetType() == FileWriterNode::TYPE_ID || n->GetNodeType() == OutputNode::NODE_TYPE)
+			n->Reset();
 	}
 }
 

--- a/src/Engine/Graph/Classifier.cpp
+++ b/src/Engine/Graph/Classifier.cpp
@@ -50,6 +50,13 @@ Classifier::Classifier(Graph* parentNode) : Graph(parentNode)
 	mIsDirty		= false;
 	mIsFinalized	= false;
 	mBufferDuration	= 10.0;
+
+	Core::AttributeSettings* attribInitTime = RegisterAttribute("Init Time (s)", "InitTime", "Required initialization time until classifier is stable.", Core::ATTRIBUTE_INTERFACETYPE_FLOATSPINNER);
+	attribInitTime->SetDefaultValue(Core::AttributeFloat::Create(DEFAULTINITTIME));
+	attribInitTime->SetMinValue(Core::AttributeFloat::Create(0.0));
+	attribInitTime->SetMaxValue(Core::AttributeFloat::Create(30.0));
+
+	CreateDefaultAttributeValues();
 }
 
 
@@ -62,11 +69,6 @@ Classifier::~Classifier()
 void Classifier::Init()
 {
 	Graph::Init();
-
-	Core::AttributeSettings* attribInitTime = RegisterAttribute("Init Time (s)", "InitTime", "Required initialization time until classifier is stable.", Core::ATTRIBUTE_INTERFACETYPE_FLOATSPINNER);
-	attribInitTime->SetDefaultValue(Core::AttributeFloat::Create(DEFAULTINITTIME));
-	attribInitTime->SetMinValue(Core::AttributeFloat::Create(0.0));
-	attribInitTime->SetMaxValue(Core::AttributeFloat::Create(30.0));
 }
 
 

--- a/src/Engine/Graph/Classifier.cpp
+++ b/src/Engine/Graph/Classifier.cpp
@@ -111,14 +111,11 @@ void Classifier::Reset()
 
 void Classifier::ResetOnSessionStart()
 {
-	uint32 num;
-
 	// reset some nodes
-	num = GetNumNodes();
+	const uint32 num = GetNumOutputNodes();
 	for (uint32_t i = 0; i < num; i++) {
-		Node* n = GetNode(i);
-		if (n->GetType() == FileWriterNode::TYPE_ID || n->GetNodeType() == OutputNode::NODE_TYPE)
-			n->Reset();
+		OutputNode* n = GetOutputNode(i);
+		n->Reset();
 	}
 }
 

--- a/src/Engine/Graph/Classifier.h
+++ b/src/Engine/Graph/Classifier.h
@@ -50,10 +50,18 @@ class ENGINE_API Classifier : public Graph, public Core::EventHandler
 	public:
 		enum { TYPE_ID = 0x1001 };
 
+		enum
+		{
+			ATTRIB_INITTIME = 0
+		};
+
+		constexpr static const double DEFAULTINITTIME = 3.0;
+
 		Classifier(Graph* parentNode=NULL);
 		virtual ~Classifier();
 
 		// main functions
+		void Init() override;
 		void Update(const Core::Time& elapsed, const Core::Time& delta) override;
 		void Reset() override;
 		void ResetOnSessionStart();

--- a/src/Engine/Graph/Classifier.h
+++ b/src/Engine/Graph/Classifier.h
@@ -55,7 +55,8 @@ class ENGINE_API Classifier : public Graph, public Core::EventHandler
 			ATTRIB_INITTIME = 0
 		};
 
-		constexpr static const double DEFAULTINITTIME = 3.0;
+		// default initialization time until e.g. filters are stable
+		constexpr static const double DEFAULTINITTIME = 2.0;
 
 		Classifier(Graph* parentNode=NULL);
 		virtual ~Classifier();

--- a/src/Engine/Graph/Classifier.h
+++ b/src/Engine/Graph/Classifier.h
@@ -56,6 +56,7 @@ class ENGINE_API Classifier : public Graph, public Core::EventHandler
 		// main functions
 		void Update(const Core::Time& elapsed, const Core::Time& delta) override;
 		void Reset() override;
+		void ResetOnSessionStart();
 
 		// overloads
 		uint32 GetType() const override							{ return TYPE_ID; }

--- a/src/Engine/Graph/Classifier.h
+++ b/src/Engine/Graph/Classifier.h
@@ -56,7 +56,7 @@ class ENGINE_API Classifier : public Graph, public Core::EventHandler
 		};
 
 		// default initialization time until e.g. filters are stable
-		constexpr static const double DEFAULTINITTIME = 2.0;
+		constexpr static const double DEFAULTINITTIME = 0.0;
 
 		Classifier(Graph* parentNode=NULL);
 		virtual ~Classifier();

--- a/src/Engine/Graph/Graph.cpp
+++ b/src/Engine/Graph/Graph.cpp
@@ -805,6 +805,14 @@ void Graph::ResetReInitReadyFlags()
 
 Json::Item Graph::Save(Json& json, Json::Item& item)
 {	
+	// graph base properties
+	item.AddString( "name", GetName() );
+	item.AddString( "uuid", GetUuid() );
+	item.AddString( "type", GetTypeUuid() );
+
+	// graph attributes
+	AttributeSet::Write(json, item, false);
+
 	// save child nodes recursively
 	if (SaveNodes(json, item) == false)
 		return json.NullItem();
@@ -862,6 +870,10 @@ bool Graph::SaveConnections(Json& json, Json::Item& item)
 bool Graph::Load(const Json& json, const Json::Item& item)
 {
 	bool success = true;
+
+	// 0: load attributes
+	if (!AttributeSet::Read(json, item, true))
+		success = false;
 
 	// 1: load all nodes
 	if (GraphImporter::LoadNodes(json, item, this) == false)

--- a/src/Engine/Session.cpp
+++ b/src/Engine/Session.cpp
@@ -38,6 +38,7 @@ Session::Session()
 	mTotalTime					= 0;
 	mElapsedTime				= 0.0;
 	mPausedTime					= 0.0;
+	mPrepareSeconds				= 0.0;
 	mPoints						= 0.0;
 	mHavePoints					= false;
 	mIsPreparing					= false;
@@ -55,10 +56,16 @@ Session::~Session()
 // prepare the session
 void Session::Prepare()
 {
-	if (mIsPreparing || mIsRunning)
+	Classifier* c = GetEngine()->GetActiveClassifier();
+
+	if (mIsPreparing || mIsRunning || !c)
 		return;
 
 	mIsPreparing = true;
+
+	// init delay of the classifier
+	mPrepareSeconds = c->GetFloatAttribute(
+		Classifier::ATTRIB_INITTIME, Classifier::DEFAULTINITTIME);
 
 	// emit event
 	EMIT_EVENT( OnPrepareSession() );
@@ -79,6 +86,9 @@ void Session::Start()
 		mIsRunning = false;
 		return;
 	}
+
+	// reset some nodes on session start
+	activeClassifier->ResetOnSessionStart();
 
 	// capture the start time and remember it
 	mStartTime = Time::Now();
@@ -126,8 +136,20 @@ void Session::Reset()
 
 
 // update the session
-void Session::Update(Core::Time delta)
+void Session::Update(const Core::Time& elapsed, const Core::Time& delta)
 {
+	Classifier* c = GetEngine()->GetActiveClassifier();
+
+	if (!c)
+		return;
+
+	// flip preparing state after init delay
+	if (mIsPreparing && elapsed.InSeconds() >= mPrepareSeconds)
+	{
+		mIsPreparing = false;
+		EMIT_EVENT( OnPreparedSession() );
+	}
+
 	// only update the session in case it is running
 	if (mIsRunning == false)
 		return;
@@ -138,14 +160,13 @@ void Session::Update(Core::Time delta)
 		mElapsedTime += delta;
 
 
-	Classifier* classifier = GetEngine()->GetActiveClassifier();
-	const uint32 numPointsNodes = classifier->GetNumPointsNodes();
+	const uint32 numPointsNodes = c->GetNumPointsNodes();
 	if (numPointsNodes > 0)
 	{
 		// sum up current total points
 		mPoints = 0;
 		for (uint32 i = 0; i < numPointsNodes; ++i)
-			mPoints += classifier->GetPointsNode(i)->GetPoints();
+			mPoints += c->GetPointsNode(i)->GetPoints();
 
 		mHavePoints	= true;
 	}

--- a/src/Engine/Session.cpp
+++ b/src/Engine/Session.cpp
@@ -40,6 +40,7 @@ Session::Session()
 	mPausedTime					= 0.0;
 	mPoints						= 0.0;
 	mHavePoints					= false;
+	mIsPreparing				= false;
 	mIsRunning					= false;
 	mIsPaused					= false;
 }
@@ -48,6 +49,19 @@ Session::Session()
 // destructor
 Session::~Session()
 {
+}
+
+
+// prepare the session
+void Session::Prepare()
+{
+	if (mIsPreparing || mIsRunning)
+		return;
+
+	mIsPreparing = true;
+
+	// emit event
+	EMIT_EVENT( OnPrepareSession() );
 }
 
 
@@ -70,6 +84,7 @@ void Session::Start()
 	mStartTime = Time::Now();
 
 	// start session
+	mIsPreparing= false;
 	mIsRunning	= true;
 	mIsPaused	= false;
 	mPoints		= 0.0;
@@ -104,6 +119,7 @@ void Session::Reset()
 	mPoints		 = 0.0;
 	mHavePoints	 = false;
 	mPausedTime  = 0.0;
+	mIsPreparing = false;
 	mIsRunning	 = false;
 	mIsPaused	 = false;
 }

--- a/src/Engine/Session.cpp
+++ b/src/Engine/Session.cpp
@@ -40,7 +40,7 @@ Session::Session()
 	mPausedTime					= 0.0;
 	mPoints						= 0.0;
 	mHavePoints					= false;
-	mIsPreparing				= false;
+	mIsPreparing					= false;
 	mIsRunning					= false;
 	mIsPaused					= false;
 }
@@ -84,7 +84,7 @@ void Session::Start()
 	mStartTime = Time::Now();
 
 	// start session
-	mIsPreparing= false;
+	mIsPreparing	= false;
 	mIsRunning	= true;
 	mIsPaused	= false;
 	mPoints		= 0.0;
@@ -119,7 +119,7 @@ void Session::Reset()
 	mPoints		 = 0.0;
 	mHavePoints	 = false;
 	mPausedTime  = 0.0;
-	mIsPreparing = false;
+	mIsPreparing	= false;
 	mIsRunning	 = false;
 	mIsPaused	 = false;
 }

--- a/src/Engine/Session.h
+++ b/src/Engine/Session.h
@@ -47,7 +47,7 @@ class ENGINE_API Session : public Core::EventSource
 		void Continue()													{ mIsPaused = false; }
 		void Reset();
 		
-		void Update(Core::Time delta);
+		void Update(const Core::Time& elapsed, const Core::Time& delta);
 
 		void SetTotalTime(Core::Time time)								{ mTotalTime = time; }
 		Core::Time GetTotalTime() const									{ return mTotalTime; }
@@ -77,6 +77,7 @@ class ENGINE_API Session : public Core::EventSource
 		Core::Time								mElapsedTime;
 		Core::Time								mPausedTime;
 
+		double									mPrepareSeconds;
 		double									mPoints;
 		bool									mHavePoints;
 

--- a/src/Engine/Session.h
+++ b/src/Engine/Session.h
@@ -40,6 +40,7 @@ class ENGINE_API Session : public Core::EventSource
 		Session();
 		virtual ~Session();
 
+		void Prepare();
 		void Start();
 		void Stop();
 		void Pause()													{ mIsPaused = true; }
@@ -58,6 +59,7 @@ class ENGINE_API Session : public Core::EventSource
 		Core::Time GetRemainingTime() const;
 		double GetProgress() const;
 
+		bool IsPreparing() const										{ return mIsPreparing; }
 		bool IsRunning() const											{ return mIsRunning; }
 		bool IsPaused() const											{ return mIsPaused; }
 
@@ -78,6 +80,7 @@ class ENGINE_API Session : public Core::EventSource
 		double									mPoints;
 		bool									mHavePoints;
 
+		bool									mIsPreparing;
 		bool									mIsRunning;
 		bool									mIsPaused;
 };

--- a/src/Studio/MainWindow.cpp
+++ b/src/Studio/MainWindow.cpp
@@ -1180,8 +1180,8 @@ QAction* MainWindow::FindAction(QList<QAction*>& actionList, Plugin* plugin)
 // EVENTS
 //
 
-// lock parts of the UI on session start
-void MainWindow::OnStartSession()
+// lock parts of the UI on session prepare
+void MainWindow::OnPrepareSession()
 {
 	mMenuBar->setEnabled(false);
 
@@ -1192,6 +1192,11 @@ void MainWindow::OnStartSession()
 	mActiveBciCombo->setEnabled(false);
 	mLayoutComboBox->setEnabled(false);
 	mSelectSessionUserButton->setEnabled(false);
+}
+
+
+void MainWindow::OnStartSession()
+{
 }
 
 

--- a/src/Studio/MainWindow.h
+++ b/src/Studio/MainWindow.h
@@ -175,6 +175,7 @@ class MainWindow : public MainWindowBase, public Core::EventHandler
 		void OnDeviceAdded(Device* device) override	final					{ ReInitBciDeviceCombo(); }
 		void OnDeviceRemoved(Device* device) override final					{ ReInitBciDeviceCombo(); }
 		void OnSessionUserChanged(const User& user) override final;
+		void OnPrepareSession() override final;
 		void OnStartSession() override final;
 		void OnStopSession() override final;
 		void OnActiveExperienceChanged(Experience* experience) override final;

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
@@ -48,6 +48,7 @@ SessionControlPlugin::SessionControlPlugin() : Plugin(GetStaticTypeUuid())
 	mLostClientError		 = false;
 	mLostDeviceError		 = false;
 	mTimer					 = NULL;
+	mIsPreparing = false;
 }
 
 
@@ -230,10 +231,11 @@ void SessionControlPlugin::UpdateWidgets()
 	
 	// show different widgets, depending on running state
 	bool isRunning = GetEngine()->GetSession()->IsRunning();
-	if (isRunning == true)
+	if (isRunning || mIsPreparing)
 	{
 		mWhileSessionWidget->show();
 		mPreSessionWidget->hide();
+      mWhileSessionWidget->SetPreparing(mIsPreparing);
 	}
 	else
 	{
@@ -483,6 +485,9 @@ void SessionControlPlugin::OnStart()
 	// make sure no session is running
 	CORE_ASSERT( GetSession()->IsRunning() == false );
 
+   mIsPreparing = true;
+   UpdateWidgets();
+
 	// reset engine but keep it paused
 	GetEngine()->Reset();
 	GetEngine()->SoftPause();
@@ -516,6 +521,7 @@ void SessionControlPlugin::OnParametersLoaded(bool success)
 
 	// start the timer for session start
 	mTimer->start(3000);
+
 }
 
 
@@ -544,6 +550,8 @@ void SessionControlPlugin::Reset()
 	
 	mLostClientError = false;
 	mLostDeviceError= false;
+
+	mIsPreparing = false;
 }
 
 
@@ -755,6 +763,7 @@ void SessionControlPlugin::OnAfterLoadLayout()
 void SessionControlPlugin::OnTimer()
 {
 	mTimer->stop();
+   mIsPreparing = false;
 
 	if (StateMachine* activeStateMachine = GetEngine()->GetActiveStateMachine())
 		activeStateMachine->Continue();

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
@@ -514,8 +514,17 @@ void SessionControlPlugin::OnParametersLoaded(bool success)
 	if (StateMachine* sm = GetEngine()->GetActiveStateMachine())
 		sm->Pause();
 
-	// start the timer for session start
-	mTimer->start(3000);
+   if (Classifier* c = GetEngine()->GetActiveClassifier())
+   {
+      const double inittime = c->GetFloatAttribute(
+         Classifier::ATTRIB_INITTIME, Classifier::DEFAULTINITTIME) * 1000.0;
+
+      // start the timer for session start
+      mTimer->start((int)inittime);
+   }
+   else
+      Reset();
+
 }
 
 

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
@@ -514,17 +514,16 @@ void SessionControlPlugin::OnParametersLoaded(bool success)
 	if (StateMachine* sm = GetEngine()->GetActiveStateMachine())
 		sm->Pause();
 
-   if (Classifier* c = GetEngine()->GetActiveClassifier())
-   {
-      const double inittime = c->GetFloatAttribute(
-         Classifier::ATTRIB_INITTIME, Classifier::DEFAULTINITTIME) * 1000.0;
+	if (Classifier* c = GetEngine()->GetActiveClassifier())
+	{
+		const double inittime = c->GetFloatAttribute(
+			Classifier::ATTRIB_INITTIME, Classifier::DEFAULTINITTIME) * 1000.0;
 
-      // start the timer for session start
-      mTimer->start((int)inittime);
-   }
-   else
-      Reset();
-
+		// start the timer for session start
+		mTimer->start((int)inittime);
+	}
+	else
+		Reset();
 }
 
 

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
@@ -47,7 +47,7 @@ SessionControlPlugin::SessionControlPlugin() : Plugin(GetStaticTypeUuid())
 	mCanStartSession		 = false;
 	mLostClientError		 = false;
 	mLostDeviceError		 = false;
-	mTimer					 = NULL;
+	mTimer				 = NULL;
 }
 
 

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
@@ -74,6 +74,7 @@ class SessionControlPlugin : public Plugin, private Core::EventSource, public Co
 
 
 		// EVENTS
+		void OnPreparedSession() override final;
 		void OnSessionUserChanged(const User& user) override final;
 		void OnActiveExperienceChanged(Experience* experience) override final				{ UpdateStartButton(); }
 		void OnActiveClassifierChanged(Classifier* experience) override final				{ UpdateStartButton(); }
@@ -88,7 +89,6 @@ class SessionControlPlugin : public Plugin, private Core::EventSource, public Co
 		void OnStop();
 		void OnPause();
 		void OnContinue();
-		void OnTimer();
 
 		// client and network message callabacks
 		void OnClientChanged   ( NetworkServerClient* client );
@@ -130,8 +130,6 @@ class SessionControlPlugin : public Plugin, private Core::EventSource, public Co
 		bool mCanStartSession;
 		bool mLostClientError;
 		bool mLostDeviceError;
-
-		QTimer* mTimer;
 };
 
 

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
@@ -131,6 +131,7 @@ class SessionControlPlugin : public Plugin, private Core::EventSource, public Co
 		bool mLostDeviceError;
 
       QTimer* mTimer;
+      bool mIsPreparing;
 
    private slots:
       void OnTimer();

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
@@ -130,6 +130,10 @@ class SessionControlPlugin : public Plugin, private Core::EventSource, public Co
 		bool mLostClientError;
 		bool mLostDeviceError;
 
+      QTimer* mTimer;
+
+   private slots:
+      void OnTimer();
 };
 
 

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
@@ -132,7 +132,6 @@ class SessionControlPlugin : public Plugin, private Core::EventSource, public Co
 		bool mLostDeviceError;
 
 		QTimer* mTimer;
-
 };
 
 

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.h
@@ -88,6 +88,7 @@ class SessionControlPlugin : public Plugin, private Core::EventSource, public Co
 		void OnStop();
 		void OnPause();
 		void OnContinue();
+		void OnTimer();
 
 		// client and network message callabacks
 		void OnClientChanged   ( NetworkServerClient* client );
@@ -130,11 +131,8 @@ class SessionControlPlugin : public Plugin, private Core::EventSource, public Co
 		bool mLostClientError;
 		bool mLostDeviceError;
 
-      QTimer* mTimer;
-      bool mIsPreparing;
+		QTimer* mTimer;
 
-   private slots:
-      void OnTimer();
 };
 
 

--- a/src/Studio/Plugins/SessionControl/WhileSessionWidget.cpp
+++ b/src/Studio/Plugins/SessionControl/WhileSessionWidget.cpp
@@ -57,6 +57,14 @@ WhileSessionWidget::WhileSessionWidget(QWidget* parent, int buttonSize) : QWidge
 	rightVLayout->setMargin(0);
 	hLayout->addLayout(rightVLayout);
 
+   mPreparing = new QLabel();
+   mPreparing->setText("Preparing");
+   QFont timeFont = mPreparing->font();
+   timeFont.setPixelSize(24);
+   mPreparing->setFont(timeFont);
+   mPreparing->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+   rightVLayout->addWidget(mPreparing, 0, Qt::AlignCenter);
+
 	// add the stopwatch widget
 	mStopwatchWidget = new StopwatchWidget(-1);
 	rightVLayout->addWidget(mStopwatchWidget);
@@ -115,4 +123,24 @@ void WhileSessionWidget::UpdateInterface()
 	// elapsed time
 	const Time timeElapsed = GetSession()->GetElapsedTime();
 	mStopwatchWidget->SetTimeInSecs(timeElapsed.InSeconds());
+}
+
+void WhileSessionWidget::SetPreparing(bool v)
+{
+   if (v)
+   {
+      mStopwatchWidget->hide();
+      mPreparing->show();
+      mContinueButton->setEnabled(false);
+      mStopButton->setEnabled(false);
+      mPauseButton->setEnabled(false);
+   }
+   else
+   {
+      mStopwatchWidget->show();
+      mPreparing->hide();
+      mContinueButton->setEnabled(true);
+      mStopButton->setEnabled(true);
+      mPauseButton->setEnabled(true);
+   }
 }

--- a/src/Studio/Plugins/SessionControl/WhileSessionWidget.cpp
+++ b/src/Studio/Plugins/SessionControl/WhileSessionWidget.cpp
@@ -57,13 +57,14 @@ WhileSessionWidget::WhileSessionWidget(QWidget* parent, int buttonSize) : QWidge
 	rightVLayout->setMargin(0);
 	hLayout->addLayout(rightVLayout);
 
-   mPreparing = new QLabel();
-   mPreparing->setText("Preparing");
-   QFont timeFont = mPreparing->font();
-   timeFont.setPixelSize(24);
-   mPreparing->setFont(timeFont);
-   mPreparing->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-   rightVLayout->addWidget(mPreparing, 0, Qt::AlignCenter);
+	// add the preparing label
+	mPreparing = new QLabel();
+	mPreparing->setText("Preparing");
+	QFont timeFont = mPreparing->font();
+	timeFont.setPixelSize(24);
+	mPreparing->setFont(timeFont);
+	mPreparing->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+	rightVLayout->addWidget(mPreparing, 0, Qt::AlignCenter);
 
 	// add the stopwatch widget
 	mStopwatchWidget = new StopwatchWidget(-1);
@@ -123,24 +124,11 @@ void WhileSessionWidget::UpdateInterface()
 	// elapsed time
 	const Time timeElapsed = GetSession()->GetElapsedTime();
 	mStopwatchWidget->SetTimeInSecs(timeElapsed.InSeconds());
-}
 
-void WhileSessionWidget::SetPreparing(bool v)
-{
-   if (v)
-   {
-      mStopwatchWidget->hide();
-      mPreparing->show();
-      mContinueButton->setEnabled(false);
-      mStopButton->setEnabled(false);
-      mPauseButton->setEnabled(false);
-   }
-   else
-   {
-      mStopwatchWidget->show();
-      mPreparing->hide();
-      mContinueButton->setEnabled(true);
-      mStopButton->setEnabled(true);
-      mPauseButton->setEnabled(true);
-   }
+	const bool isprep = GetSession()->IsPreparing();
+	mStopwatchWidget->setHidden(isprep);
+	mPreparing->setHidden(!isprep);
+	mContinueButton->setEnabled(!isprep);
+	mStopButton->setEnabled(!isprep);
+	mPauseButton->setEnabled(!isprep);
 }

--- a/src/Studio/Plugins/SessionControl/WhileSessionWidget.h
+++ b/src/Studio/Plugins/SessionControl/WhileSessionWidget.h
@@ -46,6 +46,7 @@ class WhileSessionWidget : public QWidget
 		QPushButton* GetStopButton() const		{ return mStopButton; }
 		QPushButton* GetPauseButton() const		{ return mPauseButton; }
 		QPushButton* GetContinueButton() const	{ return mContinueButton; }
+      void SetPreparing(bool v);
 
 	private:
 		Core::String		mTempString;
@@ -53,6 +54,7 @@ class WhileSessionWidget : public QWidget
 		ImageButton*		mPauseButton;
 		ImageButton*		mContinueButton;
 
+      QLabel* mPreparing;
 		StopwatchWidget*	mStopwatchWidget;
 		//QMovie*			mRunningAnimatedImage;
 		//QLabel*			mRunningLabel;

--- a/src/Studio/Plugins/SessionControl/WhileSessionWidget.h
+++ b/src/Studio/Plugins/SessionControl/WhileSessionWidget.h
@@ -53,7 +53,7 @@ class WhileSessionWidget : public QWidget
 		ImageButton*		mPauseButton;
 		ImageButton*		mContinueButton;
 
-		QLabel* 			mPreparing;
+		QLabel*					mPreparing;
 		StopwatchWidget*	mStopwatchWidget;
 		//QMovie*			mRunningAnimatedImage;
 		//QLabel*			mRunningLabel;

--- a/src/Studio/Plugins/SessionControl/WhileSessionWidget.h
+++ b/src/Studio/Plugins/SessionControl/WhileSessionWidget.h
@@ -46,7 +46,6 @@ class WhileSessionWidget : public QWidget
 		QPushButton* GetStopButton() const		{ return mStopButton; }
 		QPushButton* GetPauseButton() const		{ return mPauseButton; }
 		QPushButton* GetContinueButton() const	{ return mContinueButton; }
-      void SetPreparing(bool v);
 
 	private:
 		Core::String		mTempString;
@@ -54,7 +53,7 @@ class WhileSessionWidget : public QWidget
 		ImageButton*		mPauseButton;
 		ImageButton*		mContinueButton;
 
-      QLabel* mPreparing;
+		QLabel* 			mPreparing;
 		StopwatchWidget*	mStopwatchWidget;
 		//QMovie*			mRunningAnimatedImage;
 		//QLabel*			mRunningLabel;

--- a/src/Studio/Plugins/SessionControl/WhileSessionWidget.h
+++ b/src/Studio/Plugins/SessionControl/WhileSessionWidget.h
@@ -53,7 +53,7 @@ class WhileSessionWidget : public QWidget
 		ImageButton*		mPauseButton;
 		ImageButton*		mContinueButton;
 
-		QLabel*					mPreparing;
+		QLabel*			mPreparing;
 		StopwatchWidget*	mStopwatchWidget;
 		//QMovie*			mRunningAnimatedImage;
 		//QLabel*			mRunningLabel;


### PR DESCRIPTION
* Adds a new classifier attribute `Init time (s)` (default: `0s`) to specify init phase until e.g. filters are stable
* Add classifier attributes to serialized and persisted JSON
* Session Start: 
  * Starts a timer with specified classifier init time after resetting the Engine instead of starting session directly
  * Keeps state-machine paused during initialization phase
  * Shows a `Preparing` label in `Session Control` widget during new initialization phase
  * Starts the session after time elapses
  * Resets OutputNode and FileWriterNode once more to not persist samples from init phase
