### PR TITLE
Improve OutputNode Channel Naming

### DIFF
--- a/src/Engine/Graph/CustomFeedbackNode.cpp
+++ b/src/Engine/Graph/CustomFeedbackNode.cpp
@@ -191,14 +191,6 @@ void CustomFeedbackNode::Update(const Time& elapsed, const Time& delta)
 	}
 }
 
-
-void CustomFeedbackNode::SetName(const char* name)
-{
-	FeedbackNode::SetName(name);
-	mChannels[0]->SetName(name);
-}
-
-
 // attributes have changed
 void CustomFeedbackNode::OnAttributesChanged()
 {

--- a/src/Engine/Graph/CustomFeedbackNode.h
+++ b/src/Engine/Graph/CustomFeedbackNode.h
@@ -76,8 +76,6 @@ class ENGINE_API CustomFeedbackNode : public FeedbackNode
 		const char* GetRuleName() const override 								{ return "NODE_Feedback"; }
 		GraphObject* Clone(Graph* graph) override								{ CustomFeedbackNode* clone = new CustomFeedbackNode(graph); return clone; }
 
-		void SetName(const char* name) override;
-
 		// accessors
 		bool IsRanged() const													{ return GetBoolAttribute(ATTRIB_ISRANGED); }
 		double GetRangeMin() const override										{ return GetFloatAttribute(ATTRIB_RANGEMIN); }

--- a/src/Engine/Graph/OutputNode.cpp
+++ b/src/Engine/Graph/OutputNode.cpp
@@ -85,7 +85,7 @@ void OutputNode::Start(const Time& elapsed)
 	mInputReader.Start(startTime);
 
 	// whether to use node or channel name for output
-	const bool usechannelname = this->GetInt32AttributeByName("outputName") == 1;
+	const bool usechannelname = this->GetInt32Attribute(ATTRIB_OUTPUTNAME) == 1;
 
 	int readerIndex = 0;
 	const uint32 numChannels = mChannels.Size();

--- a/src/Engine/Graph/OutputNode.cpp
+++ b/src/Engine/Graph/OutputNode.cpp
@@ -57,6 +57,13 @@ void OutputNode::Init()
 	// upload checkbox
 	AttributeSettings* attributeUpload = RegisterAttribute("Upload", "upload", "Upload the data stream to neuromore Cloud after a successful session.", ATTRIBUTE_INTERFACETYPE_CHECKBOX);
 	attributeUpload->SetDefaultValue(AttributeBool::Create(false));
+
+	// output name
+	AttributeSettings* outputName = RegisterAttribute("Output Name", "outputName", "Select name of output/upload.", ATTRIBUTE_INTERFACETYPE_COMBOBOX);
+	outputName->ResizeComboValues(2);
+	outputName->SetComboValue(0, "Use Node Name");
+	outputName->SetComboValue(1, "Use Channel Name");
+	outputName->SetDefaultValue(AttributeInt32::Create(0));
 }
 
 
@@ -76,6 +83,9 @@ void OutputNode::Start(const Time& elapsed)
 	// start input readers
 	const Time startTime = mInputReader.FindMinLastSampleTime();
 	mInputReader.Start(startTime);
+
+	// whether to use node or channel name for output
+	const bool usechannelname = this->GetInt32AttributeByName("outputName") == 1;
 
 	int readerIndex = 0;
 	const uint32 numChannels = mChannels.Size();
@@ -103,6 +113,7 @@ void OutputNode::Start(const Time& elapsed)
 			// set start times
 			mResamplers[i].SetStartTime(startTime);
 			mChannels[i]->SetStartTime(startTime);
+			mChannels[i]->SetName(usechannelname ? inputChannel->GetName() : this->GetName());
 
 			// finally reinit resampler
 			mResamplers[i].ReInit();

--- a/src/Engine/Graph/OutputNode.h
+++ b/src/Engine/Graph/OutputNode.h
@@ -43,7 +43,8 @@ class ENGINE_API OutputNode : public SPNode
 		{
 			ATTRIB_SIGNALRESOLUTION = 0,
 			ATTRIB_UPLOAD			= 1,
-			NUM_BASEATTRIBUTES		= 2
+			ATTRIB_OUTPUTNAME		= 2,
+			NUM_BASEATTRIBUTES		= 3
 		};
 
 		enum SignalResolution


### PR DESCRIPTION
Adds new `Output Name` Attribute to `OutputNode`.
Allows to use (dynamic) input channel name instead of (fixed) node name in use cases with naming (e.g. upload).
Default is backwards compatible using node name.

![cfn-name](https://github.com/neuromore/studio/assets/780159/bd33f645-d25c-4ffa-a935-7716d375788f)
