### PR TITLE
Misc. Changes

### DIFF
--- a/src/Engine/BciDevice.cpp
+++ b/src/Engine/BciDevice.cpp
@@ -32,6 +32,14 @@
 
 using namespace Core;
 
+// impedance/signalquality profiles
+BciDevice::ImpedanceThreshold BciDevice::ImpedanceThresholds[] = {
+   BciDevice::ImpedanceThreshold("Research",        5.0,  10.0,  20.0,  80.0),
+   BciDevice::ImpedanceThreshold("Neurofeedback",  10.0,  20.0,  40.0,  80.0),
+   BciDevice::ImpedanceThreshold("Testing",       100.0, 200.0, 300.0, 400.0)
+};
+
+
 // constructor
 BciDevice::BciDevice(DeviceDriver* deviceDriver) : Device(deviceDriver)
 {

--- a/src/Engine/BciDevice.cpp
+++ b/src/Engine/BciDevice.cpp
@@ -73,6 +73,7 @@ void BciDevice::CreateSensors()
 	{
 		// create sensor with the neuro headset sample rate
 		Sensor* sensor = new Sensor(mElectrodes[i].GetName(), GetSampleRate());
+		sensor->GetChannel()->SetBufferSizeInSeconds(DEFAULTBUFFERSIZEINSECONDS);
 
 		// set unique color for each sensor
 		sensor->GetChannel()->GetColor().SetUniqueColor(i);

--- a/src/Engine/BciDevice.cpp
+++ b/src/Engine/BciDevice.cpp
@@ -32,13 +32,6 @@
 
 using namespace Core;
 
-// impedance/signalquality profiles
-BciDevice::ImpedanceThreshold BciDevice::ImpedanceThresholds[] = {
-   BciDevice::ImpedanceThreshold("Research",        5.0,  10.0,  20.0,  80.0),
-   BciDevice::ImpedanceThreshold("Neurofeedback",  10.0,  20.0,  40.0,  80.0),
-   BciDevice::ImpedanceThreshold("Testing",       100.0, 200.0, 300.0, 400.0)
-};
-
 
 // constructor
 BciDevice::BciDevice(DeviceDriver* deviceDriver) : Device(deviceDriver)

--- a/src/Engine/BciDevice.cpp
+++ b/src/Engine/BciDevice.cpp
@@ -32,7 +32,6 @@
 
 using namespace Core;
 
-
 // constructor
 BciDevice::BciDevice(DeviceDriver* deviceDriver) : Device(deviceDriver)
 {

--- a/src/Engine/BciDevice.h
+++ b/src/Engine/BciDevice.h
@@ -38,6 +38,8 @@ class ENGINE_API BciDevice : public Device
 	public:
 		enum { BASE_TYPE_ID = 0x02 };
 
+		static constexpr const double DEFAULTBUFFERSIZEINSECONDS = 60.0;
+
 		// constructor & destructor
 		BciDevice(DeviceDriver* driver = NULL);
 		virtual ~BciDevice();

--- a/src/Engine/BciDevice.h
+++ b/src/Engine/BciDevice.h
@@ -38,6 +38,24 @@ class ENGINE_API BciDevice : public Device
 	public:
 		enum { BASE_TYPE_ID = 0x02 };
 
+		// impedance/signalquality threshold set
+		class ImpedanceThreshold
+		{
+		public:
+			const char*  name;
+			const double green;
+			const double yellow;
+			const double orange;
+			const double red;
+			inline ImpedanceThreshold(const char* n, double g = 0.0, double y = 0.0, double o = 0.0, double r = 0.0) :
+				name(n), green(g), yellow(y), orange(o), red(r) { }
+		};
+
+		static constexpr const size_t NUMIMPEDANCEPROFILES    = 3;
+		static constexpr const size_t DEFAULTIMPEDANCEPROFILE = 1;
+
+		static ImpedanceThreshold ImpedanceThresholds[NUMIMPEDANCEPROFILES];
+
 		// constructor & destructor
 		BciDevice(DeviceDriver* driver = NULL);
 		virtual ~BciDevice();

--- a/src/Engine/BciDevice.h
+++ b/src/Engine/BciDevice.h
@@ -38,24 +38,6 @@ class ENGINE_API BciDevice : public Device
 	public:
 		enum { BASE_TYPE_ID = 0x02 };
 
-		// impedance/signalquality threshold set
-		class ImpedanceThreshold
-		{
-		public:
-			const char*  name;
-			const double green;
-			const double yellow;
-			const double orange;
-			const double red;
-			inline ImpedanceThreshold(const char* n, double g = 0.0, double y = 0.0, double o = 0.0, double r = 0.0) :
-				name(n), green(g), yellow(y), orange(o), red(r) { }
-		};
-
-		static constexpr const size_t NUMIMPEDANCEPROFILES    = 3;
-		static constexpr const size_t DEFAULTIMPEDANCEPROFILE = 1;
-
-		static ImpedanceThreshold ImpedanceThresholds[NUMIMPEDANCEPROFILES];
-
 		// constructor & destructor
 		BciDevice(DeviceDriver* driver = NULL);
 		virtual ~BciDevice();

--- a/src/Engine/Branding.h
+++ b/src/Engine/Branding.h
@@ -52,6 +52,7 @@ public:
    static constexpr const char* AboutImageName              = ":/Images/About-neuromore.png";
    static constexpr const bool  LoginRemberMePrechecked     = true;
    static constexpr const bool  HasColorCodesForChannels    = false;
+   static constexpr const bool  HasMinimalDeviceInfo        = true;
    static constexpr const bool  DefaultAutoDetectionEnabled = true;
    static constexpr const bool  DefaultTestDeviceEnabled    = true;
    static constexpr const bool  DefaultEemagineEnabled      = true;

--- a/src/Engine/Branding.h
+++ b/src/Engine/Branding.h
@@ -52,7 +52,7 @@ public:
    static constexpr const char* AboutImageName              = ":/Images/About-neuromore.png";
    static constexpr const bool  LoginRemberMePrechecked     = true;
    static constexpr const bool  HasColorCodesForChannels    = false;
-   static constexpr const bool  HasMinimalDeviceInfo        = true;
+   static constexpr const bool  HasMinimalDeviceInfo        = false;
    static constexpr const bool  DefaultAutoDetectionEnabled = true;
    static constexpr const bool  DefaultTestDeviceEnabled    = true;
    static constexpr const bool  DefaultEemagineEnabled      = true;

--- a/src/Engine/Branding.h
+++ b/src/Engine/Branding.h
@@ -51,6 +51,7 @@ public:
    static constexpr const char* SplashImageName             = ":/Images/SplashScreen-neuromore.png";
    static constexpr const char* AboutImageName              = ":/Images/About-neuromore.png";
    static constexpr const bool  LoginRemberMePrechecked     = true;
+   static constexpr const bool  HasColorCodesForChannels    = false;
    static constexpr const bool  DefaultAutoDetectionEnabled = true;
    static constexpr const bool  DefaultTestDeviceEnabled    = true;
    static constexpr const bool  DefaultEemagineEnabled      = true;

--- a/src/Engine/Devices/OpenBCI/OpenBCIDevices.cpp
+++ b/src/Engine/Devices/OpenBCI/OpenBCIDevices.cpp
@@ -39,6 +39,9 @@ OpenBCIDeviceBase::OpenBCIDeviceBase(DeviceDriver* driver) : BciDevice(driver),
    mTesting(false), mAccForwardSensor(0), mAccUpSensor(0), mAccLeftSensor(0)
 { 
    mState = STATE_IDLE;
+   //TEST
+   mPowerSupplyType = POWERSUPPLY_BATTERY;
+   mReceivedWirelessSignalQuality = true;
 }
 
 void OpenBCIDeviceBase::CreateSensors()
@@ -64,22 +67,6 @@ void OpenBCIDeviceBase::CreateSensors()
 	AddSensor(mAccLeftSensor);
 }
 
-void OpenBCIDeviceBase::StartTest()
-{
-   if (mTesting)
-      return;
-
-   mTesting = true;
-}
-
-void OpenBCIDeviceBase::StopTest()
-{
-   if (!mTesting)
-      return;
-
-   mTesting = false;
-}
-
 
 //
 // OpenBCI without Daisy module
@@ -95,9 +82,6 @@ OpenBCIDevice::OpenBCIDevice(DeviceDriver* driver) : OpenBCIDeviceBase(driver)
 
 	// create all sensors
 	CreateSensors();
-
-	// go into test mode directly
-	StartTest();
 }
 
 

--- a/src/Engine/Devices/OpenBCI/OpenBCIDevices.cpp
+++ b/src/Engine/Devices/OpenBCI/OpenBCIDevices.cpp
@@ -39,9 +39,6 @@ OpenBCIDeviceBase::OpenBCIDeviceBase(DeviceDriver* driver) : BciDevice(driver),
    mTesting(false), mAccForwardSensor(0), mAccUpSensor(0), mAccLeftSensor(0)
 { 
    mState = STATE_IDLE;
-   //TEST
-   mPowerSupplyType = POWERSUPPLY_BATTERY;
-   mReceivedWirelessSignalQuality = true;
 }
 
 void OpenBCIDeviceBase::CreateSensors()

--- a/src/Engine/Devices/OpenBCI/OpenBCIDevices.cpp
+++ b/src/Engine/Devices/OpenBCI/OpenBCIDevices.cpp
@@ -49,18 +49,21 @@ void OpenBCIDeviceBase::CreateSensors()
 	mAccForwardSensor->GetChannel()->SetMinValue(-2000.0);
 	mAccForwardSensor->GetChannel()->SetMaxValue(1996.1);
 	mAccForwardSensor->GetChannel()->SetUnit("mm/s^2");
+	mAccForwardSensor->GetChannel()->SetBufferSizeInSeconds(DEFAULTBUFFERSIZEINSECONDS);
 	AddSensor(mAccForwardSensor);
 
 	mAccUpSensor = new Sensor("Acc (Up)", 250);
 	mAccUpSensor->GetChannel()->SetMinValue(-2000.0);
 	mAccUpSensor->GetChannel()->SetMaxValue(1996.1);
 	mAccUpSensor->GetChannel()->SetUnit("mm/s^2");
+	mAccUpSensor->GetChannel()->SetBufferSizeInSeconds(DEFAULTBUFFERSIZEINSECONDS);
 	AddSensor(mAccUpSensor);
 
 	mAccLeftSensor = new Sensor("Acc (Left)", 250);
 	mAccLeftSensor->GetChannel()->SetMinValue(-2000.0);
 	mAccLeftSensor->GetChannel()->SetMaxValue(1996.1);
 	mAccLeftSensor->GetChannel()->SetUnit("mm/s^2");
+	mAccLeftSensor->GetChannel()->SetBufferSizeInSeconds(DEFAULTBUFFERSIZEINSECONDS);
 	AddSensor(mAccLeftSensor);
 }
 

--- a/src/Engine/Devices/OpenBCI/OpenBCIDevices.h
+++ b/src/Engine/Devices/OpenBCI/OpenBCIDevices.h
@@ -86,14 +86,12 @@ public:
    double GetLatency() const override        { return 0.1; }
    double GetExpectedJitter() const override { return 0.1; }
    bool IsWireless() const override          { return true; }
-   bool HasTestMode() const override         { return true; }
+   bool HasTestMode() const override         { return false; }
 
    void CreateSensors() override;
 
-   void StartTest() override;
-   void StopTest() override;
-   inline bool IsTestRunning() override { return mTesting; }
-   inline bool HasEegContactQualityIndicator() override { return mTesting; }
+   inline bool IsTestRunning() override { return true; }
+   inline bool HasEegContactQualityIndicator() override { return true; }
 
    virtual void AddSample(uint32 idx, double v) = 0;
 

--- a/src/Engine/Graph/ChannelSelectorNode.cpp
+++ b/src/Engine/Graph/ChannelSelectorNode.cpp
@@ -237,7 +237,7 @@ void ChannelSelectorNode::CollectSelectedInputChannels()
 			for (uint32 j=0; j<numInputChannels; ++j)
 			{
 				ChannelBase* channel = mInputReader.GetChannel(j);
-				if ((name.IsValidInt() && name.ToInt() == j+1) || channel->GetNameString().IsEqual(name))
+				if ((name.IsValidInt() && name.ToInt() == (int)(j+1)) || channel->GetNameString().IsEqual(name))
 				{
 					// found it
 					channelIndex = j;

--- a/src/Engine/Graph/Classifier.h
+++ b/src/Engine/Graph/Classifier.h
@@ -169,6 +169,7 @@ class ENGINE_API Classifier : public Graph, public Core::EventHandler
 
 		void CollectUsedSensors();
 		bool IsSensorUsed (Sensor* sensor) const							{ return mUsedSensors.Contains(sensor); }
+		uint32 GetNumUsedSensors() const							{ return mUsedSensors.Size(); }
 
 		//
 		//  Classifier Control

--- a/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
@@ -113,21 +113,23 @@ void BciDeviceWidget::Init()
 			lbl->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 			lbl->setAlignment(Qt::AlignCenter);
 
-			// custom coloring
-			switch (i)
+			if (Branding::HasColorCodesForChannels)
 			{
-			/*
-			case 0:  lbl->setStyleSheet("color: brown;  background-color: black;"); break;
-			case 1:  lbl->setStyleSheet("color: red;    background-color: black;"); break;
-			case 2:  lbl->setStyleSheet("color: orange; background-color: black;"); break;
-			case 3:  lbl->setStyleSheet("color: yellow; background-color: black;"); break;
-			case 4:  lbl->setStyleSheet("color: green;  background-color: black;"); break;
-			case 5:  lbl->setStyleSheet("color: blue;   background-color: black;"); break;
-			case 6:  lbl->setStyleSheet("color: purple; background-color: black;"); break;
-			case 7:  lbl->setStyleSheet("color: grey;   background-color: black;"); break;
-			*/
-			default: lbl->setStyleSheet("color: white;  background-color: black;"); break;
+				switch (i)
+				{
+				case 0:  lbl->setStyleSheet("color: brown;  background-color: black;"); break;
+				case 1:  lbl->setStyleSheet("color: red;    background-color: black;"); break;
+				case 2:  lbl->setStyleSheet("color: orange; background-color: black;"); break;
+				case 3:  lbl->setStyleSheet("color: yellow; background-color: black;"); break;
+				case 4:  lbl->setStyleSheet("color: green;  background-color: black;"); break;
+				case 5:  lbl->setStyleSheet("color: blue;   background-color: black;"); break;
+				case 6:  lbl->setStyleSheet("color: purple; background-color: black;"); break;
+				case 7:  lbl->setStyleSheet("color: grey;   background-color: black;"); break;
+				default: lbl->setStyleSheet("color: white;  background-color: black;"); break;
+				}
 			}
+			else
+				lbl->setStyleSheet("color: white;  background-color: black;");
 
 			// value label
 			QLabel* val = new QLabel();

--- a/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
@@ -207,7 +207,7 @@ void BciDeviceWidget::UpdateInterface()
 		static_cast<ImpedanceTestWidget*>(mDeviceTestWidget)->UpdateInterface();
 
 	// update impedance grid
-	if (mBciDevice && mBciDevice->IsTestRunning() && mImpedanceGridWidget && mImpedanceGrid && mImpedanceGrid->rowCount() > 0)
+	if (mBciDevice && mImpedanceGridWidget && mImpedanceGrid && mImpedanceGrid->rowCount() > 0)
 	{
 		Classifier* classifier = GetEngine()->GetActiveClassifier();
 		mImpedanceGridWidget->setVisible(mBciDevice->HasEegContactQualityIndicator());

--- a/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
@@ -206,8 +206,8 @@ void BciDeviceWidget::UpdateInterface()
 		Classifier* classifier = GetEngine()->GetActiveClassifier();
 		mImpedanceGridWidget->setVisible(mBciDevice->HasEegContactQualityIndicator());
 		const uint32 numSensors = std::min(
-			(uint32)mImpedanceGrid->rowCount()-1U, 
-			mBciDevice->GetNumNeuroSensors());
+			(uint32)mImpedanceGrid->rowCount()-4U, 
+			std::min(8U, mBciDevice->GetNumNeuroSensors()));
 		const uint32 numUsedSensors = classifier ? classifier->GetNumUsedSensors() : 0U;
 		double max = DBL_MIN;
 		double avg = 0.0;

--- a/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
@@ -77,7 +77,7 @@ void BciDeviceWidget::Init()
 	mImpedanceGrid = new QGridLayout(mImpedanceGridWidget);
 	mImpedanceGrid->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 	mImpedanceGrid->setSizeConstraint(QLayout::SetMinimumSize);
-	mImpedanceGrid->setContentsMargins(QMargins(32, 0, 0, 0));
+	mImpedanceGrid->setContentsMargins(QMargins(16, 0, 0, 0));
 
 	const QSize lblsize(30, 20);
 	const QSize valsize(50, 20);
@@ -206,7 +206,7 @@ void BciDeviceWidget::UpdateInterface()
 	if (mBciDevice && mBciDevice->IsTestRunning() && mImpedanceGridWidget && mImpedanceGrid && mImpedanceGrid->rowCount() > 0)
 	{
 		Classifier* classifier = GetEngine()->GetActiveClassifier();
-		//mImpedanceGridWidget->setVisible(mBciDevice->HasEegContactQualityIndicator());
+		mImpedanceGridWidget->setVisible(mBciDevice->HasEegContactQualityIndicator());
 		const uint32 numSensors = std::min(
 			(uint32)mImpedanceGrid->rowCount()-1U, 
 			mBciDevice->GetNumNeuroSensors());

--- a/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
@@ -29,12 +29,6 @@
 
 using namespace Core;
 
-#if defined(NEUROMORE_BRANDING_ANT) && defined(PRODUCTION_BUILD)
-#define NEUROMORE_MINIMAL_DEVICE_STATS true
-#else
-#define NEUROMORE_MINIMAL_DEVICE_STATS false
-#endif
-
 // constructor
 BciDeviceWidget::BciDeviceWidget(BciDevice* device, QWidget* parent) : DeviceWidget(device, parent)
 {
@@ -305,12 +299,12 @@ void BciDeviceWidget::AddSensorItems(QTreeWidgetItem* parent)
 		// add signal quality subitem
 		item = new QTreeWidgetItem(sensorItem);
 		item->setText(0, "Signal Quality");
-		item->setHidden(NEUROMORE_MINIMAL_DEVICE_STATS);
+		item->setHidden(Branding::HasMinimalDeviceInfo);
 
 		// add current value subitem
 		item = new QTreeWidgetItem(sensorItem);
 		item->setText(0, "Current Value");
-		item->setHidden(NEUROMORE_MINIMAL_DEVICE_STATS);
+		item->setHidden(Branding::HasMinimalDeviceInfo);
 
 		// add sample rate subitem
 		item = new QTreeWidgetItem(sensorItem);
@@ -319,17 +313,16 @@ void BciDeviceWidget::AddSensorItems(QTreeWidgetItem* parent)
 		// add drift correction subitem
 		item = new QTreeWidgetItem(sensorItem);
 		item->setText(0, "Drift (Corrected)");
-		item->setHidden(NEUROMORE_MINIMAL_DEVICE_STATS);
+		item->setHidden(Branding::HasMinimalDeviceInfo);
 
 		// add burst size subitem
 		item = new QTreeWidgetItem(sensorItem);
 		item->setText(0, "Max/Avg Burst Size");
-		item->setHidden(NEUROMORE_MINIMAL_DEVICE_STATS);
 
 		// add burst size subitem
 		item = new QTreeWidgetItem(sensorItem);
 		item->setText(0, "Max Latency");
-		item->setHidden(NEUROMORE_MINIMAL_DEVICE_STATS);
+		item->setHidden(Branding::HasMinimalDeviceInfo);
 
 		// add sample counter subitem
 		item = new QTreeWidgetItem(sensorItem);
@@ -342,7 +335,7 @@ void BciDeviceWidget::AddSensorItems(QTreeWidgetItem* parent)
 		// add total memory subitem
 		item = new QTreeWidgetItem(sensorItem);
 		item->setText(0, "Memory Used");
-		item->setHidden(NEUROMORE_MINIMAL_DEVICE_STATS);
+		item->setHidden(Branding::HasMinimalDeviceInfo);
 	}
 }
 

--- a/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
@@ -116,6 +116,7 @@ void BciDeviceWidget::Init()
 			// custom coloring
 			switch (i)
 			{
+			/*
 			case 0:  lbl->setStyleSheet("color: brown;  background-color: black;"); break;
 			case 1:  lbl->setStyleSheet("color: red;    background-color: black;"); break;
 			case 2:  lbl->setStyleSheet("color: orange; background-color: black;"); break;
@@ -124,6 +125,7 @@ void BciDeviceWidget::Init()
 			case 5:  lbl->setStyleSheet("color: blue;   background-color: black;"); break;
 			case 6:  lbl->setStyleSheet("color: purple; background-color: black;"); break;
 			case 7:  lbl->setStyleSheet("color: grey;   background-color: black;"); break;
+			*/
 			default: lbl->setStyleSheet("color: white;  background-color: black;"); break;
 			}
 

--- a/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/BciDeviceWidget.cpp
@@ -234,10 +234,10 @@ void BciDeviceWidget::UpdateInterface()
 			{
 				if (impedance > 0.1)
 				{
-               if (impedance > max) max = impedance;
-               if (impedance < min) min = impedance;
-               avg += impedance;
-               cnt++;
+					max = impedance > max ? impedance : max;
+					min = impedance < min ? impedance : min;
+					avg += impedance;
+					cnt++;
 				}
 			}
 			else
@@ -247,19 +247,19 @@ void BciDeviceWidget::UpdateInterface()
 				color.ToHexString().AsChar()));
 		}
 
-      if (cnt) avg /= cnt;
+		if (cnt) avg /= cnt;
 
-      QLabel* lblmin = (QLabel*)mImpedanceGrid->itemAtPosition(numSensors + 1, 1)->widget();
-      if (min >= 0.1 && min < DBL_MAX) lblmin->setText(QString().sprintf("%5.1f", min));
-      else lblmin->setText("");
+		QLabel* lblmin = (QLabel*)mImpedanceGrid->itemAtPosition(numSensors + 1, 1)->widget();
+		if (min >= 0.1 && min < DBL_MAX) lblmin->setText(QString().sprintf("%5.1f", min));
+		else lblmin->setText("");
 
-      QLabel* lblavg = (QLabel*)mImpedanceGrid->itemAtPosition(numSensors + 2, 1)->widget();
-      if (avg >= 0.1) lblavg->setText(QString().sprintf("%5.1f", avg));
-      else lblavg->setText("");
+		QLabel* lblavg = (QLabel*)mImpedanceGrid->itemAtPosition(numSensors + 2, 1)->widget();
+		if (avg >= 0.1) lblavg->setText(QString().sprintf("%5.1f", avg));
+		else lblavg->setText("");
 
-      QLabel* lblmax = (QLabel*)mImpedanceGrid->itemAtPosition(numSensors + 3, 1)->widget();
-      if (max >= 0.1) lblmax->setText(QString().sprintf("%5.1f", max));
-      else lblmax->setText("");
+		QLabel* lblmax = (QLabel*)mImpedanceGrid->itemAtPosition(numSensors + 3, 1)->widget();
+		if (max >= 0.1) lblmax->setText(QString().sprintf("%5.1f", max));
+		else lblmax->setText("");
 	}
 }
 

--- a/src/Studio/Plugins/Devices/DeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/DeviceWidget.cpp
@@ -62,7 +62,6 @@ void DeviceWidget::Init()
 	//mLayout->setSpacing(0);
 
 	//mLayout->addWidget(QLabel( mDevice->GetName().AsChar() ));
-   constexpr int firstcolumnwidth = 160;
 
 	// top: device icon (if one exists)
 	String iconFilename;
@@ -74,12 +73,12 @@ void DeviceWidget::Init()
 	{
 		mDeviceIcon = new QLabel();
 		mDeviceIcon->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-      //mDeviceIcon->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
+		//mDeviceIcon->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
 		mLayout->addWidget(mDeviceIcon, 0, 0);
 
 		// scale and apply icon
 		QPixmap icon(iconFilename.AsChar());
-		icon = icon.scaledToWidth(firstcolumnwidth, Qt::TransformationMode::SmoothTransformation);
+		icon = icon.scaledToWidth(160, Qt::TransformationMode::SmoothTransformation);
 		mDeviceIcon->setPixmap(icon);
 	}
 	else
@@ -107,8 +106,8 @@ void DeviceWidget::Init()
 	connect(mDeviceInfoButton, SIGNAL(clicked()), this, SLOT(OnDeviceInfoButtonPressed()));
 	buttonLayout->addWidget(mDeviceInfoButton);
 	
-	// create test button only if device has a test mode or test is running
-	if (mDevice->HasTestMode())
+	// create test button only if device has a test mode
+	if (mDevice->HasTestMode() == true)
 	{
 		// "Test" Button
 		mDeviceTestButton = new QPushButton("Test");
@@ -141,7 +140,7 @@ void DeviceWidget::Init()
 
 	// 3) device information tree (lower half of main layout)
 	mDeviceInfoTree = new QTreeWidget();
-	mDeviceInfoTree->setFixedHeight(90);
+	mDeviceInfoTree->setFixedHeight(14 * 4);
 	mDeviceInfoTree->setSelectionMode( QAbstractItemView::SingleSelection);
 	mDeviceInfoTree->setSortingEnabled(false);
 	mDeviceInfoTree->setAlternatingRowColors(true);

--- a/src/Studio/Plugins/Devices/DeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/DeviceWidget.cpp
@@ -42,8 +42,7 @@ DeviceWidget::DeviceWidget(Device* device, QWidget* parent) : QWidget(parent)
 	mDeviceTestWidget = NULL;
 	
 	mDevice = device;
-
-	setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Maximum );
+	setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding);
 }
 
 
@@ -60,6 +59,7 @@ void DeviceWidget::Init()
 	mLayout = new QGridLayout();
 	mLayout->setMargin(0);
 	//mLayout->setSpacing(0);
+	mLayout->setAlignment(Qt::AlignTop);
 
 	//mLayout->addWidget(QLabel( mDevice->GetName().AsChar() ));
 
@@ -135,11 +135,12 @@ void DeviceWidget::Init()
 	// 2) right half of widget area (primary device info)
 	mPrimaryDeviceInfoLayout = new QHBoxLayout();
 	mPrimaryDeviceInfoLayout->setMargin(0);
-	mLayout->addLayout(mPrimaryDeviceInfoLayout, 0, 1, 4, 1);
+	mLayout->addLayout(mPrimaryDeviceInfoLayout, 0, 1, 4, 1, Qt::AlignTop);
 
 	// 3) device information tree (lower half of main layout)
 	mDeviceInfoTree = new QTreeWidget();
-	mDeviceInfoTree->setFixedHeight(4 * 28);
+	mDeviceInfoTree->setMinimumHeight(70);
+	mDeviceInfoTree->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 	mDeviceInfoTree->setSelectionMode( QAbstractItemView::SingleSelection);
 	mDeviceInfoTree->setSortingEnabled(false);
 	mDeviceInfoTree->setAlternatingRowColors(true);

--- a/src/Studio/Plugins/Devices/DeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/DeviceWidget.cpp
@@ -73,7 +73,7 @@ void DeviceWidget::Init()
 	{
 		mDeviceIcon = new QLabel();
 		mDeviceIcon->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-		//mDeviceIcon->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
+
 		mLayout->addWidget(mDeviceIcon, 0, 0);
 
 		// scale and apply icon
@@ -89,7 +89,6 @@ void DeviceWidget::Init()
 	mSecondaryDeviceInfoLayout->setContentsMargins(0, 8, 0, 8);
 	mBatteryStatusWidget = new BatteryStatusWidget(this);
 	mBatteryStatusWidget->setVisible(mDevice->HasBatteryIndicator());
-	//mBatteryStatusWidget->setStyleSheet("background-color: black;");
 
 	mSecondaryDeviceInfoLayout->addWidget(mBatteryStatusWidget);
 	mLayout->addLayout(mSecondaryDeviceInfoLayout, 1, 0, Qt::AlignLeft | Qt::AlignVCenter);
@@ -140,7 +139,7 @@ void DeviceWidget::Init()
 
 	// 3) device information tree (lower half of main layout)
 	mDeviceInfoTree = new QTreeWidget();
-	mDeviceInfoTree->setFixedHeight(14 * 4);
+	mDeviceInfoTree->setFixedHeight(4 * 28);
 	mDeviceInfoTree->setSelectionMode( QAbstractItemView::SingleSelection);
 	mDeviceInfoTree->setSortingEnabled(false);
 	mDeviceInfoTree->setAlternatingRowColors(true);

--- a/src/Studio/Plugins/Devices/DeviceWidget.cpp
+++ b/src/Studio/Plugins/Devices/DeviceWidget.cpp
@@ -252,12 +252,14 @@ void DeviceWidget::AddDeviceItems()
 	item->setText(0, "Device Name");
 	item->setText(1, mDevice->GetName().AsChar());
 	mDeviceInfoTree->addTopLevelItem(item);
+	item->setHidden(Branding::HasMinimalDeviceInfo);
 
 	// Memory usage
 	item = new QTreeWidgetItem();
 	item->setText(0, "Memory Used");
 	item->setText(1, "0 KB");
 	mDeviceInfoTree->addTopLevelItem(item);
+	item->setHidden(Branding::HasMinimalDeviceInfo);
 }
 
 

--- a/src/Studio/Plugins/Devices/DeviceWidget.h
+++ b/src/Studio/Plugins/Devices/DeviceWidget.h
@@ -74,7 +74,7 @@ class DeviceWidget : public QWidget
 		// UI elements
 		QGridLayout*			mLayout;						// main layout
 		QHBoxLayout*			mPrimaryDeviceInfoLayout;		// the right half of the device status panel
-		QVBoxLayout*			mSecondaryDeviceInfoLayout;		// the area on the left under the device icon
+		QHBoxLayout*			mSecondaryDeviceInfoLayout;		// the area on the left under the device icon
 		QLabel*					mDeviceIcon;					// photographic icon (large size)
 		QPushButton*			mDeviceInfoButton;				// show/hide button for device information tree
 		QPushButton*			mDeviceTestButton;				// show/hide button for device information test
@@ -94,7 +94,7 @@ class DeviceWidget : public QWidget
 		QWidget*				mDeviceTestWidget;
 
 		inline QHBoxLayout* GetPrimaryDeviceInfoLayout()				{ return mPrimaryDeviceInfoLayout; }
-		inline QVBoxLayout* GetSecondaryDeviceInfoLayout()				{ return mSecondaryDeviceInfoLayout; }
+		inline QHBoxLayout* GetSecondaryDeviceInfoLayout()				{ return mSecondaryDeviceInfoLayout; }
 		void AddDeviceInfo (const char* name, QWidget* value);
 
 		// helpers

--- a/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
+++ b/src/Studio/Plugins/SessionControl/SessionControlPlugin.cpp
@@ -839,7 +839,7 @@ void SessionControlPlugin::ShowReport()
 // called after switching layout
 void SessionControlPlugin::OnAfterLoadLayout()
 {
-	if (GetUser()->FindRule("STUDIO_SETTING_EasyWorkflow") != NULL)
+	/*if (GetUser()->FindRule("STUDIO_SETTING_EasyWorkflow") != NULL)
 	{
 		// open visualization select window if one is available and none is running
 		VisualizationManager* vizManager = GetManager()->GetVisualizationManager();
@@ -848,5 +848,5 @@ void SessionControlPlugin::OnAfterLoadLayout()
 			VisualizationSelectWindow selectVizWindow(GetMainWindow());
 			selectVizWindow.exec();
 		}
-	}
+	}*/
 }

--- a/src/Studio/Widgets/BatteryStatusWidget.cpp
+++ b/src/Studio/Widgets/BatteryStatusWidget.cpp
@@ -32,7 +32,7 @@ using namespace Core;
 // constructor
 BatteryStatusWidget::BatteryStatusWidget(QWidget* parent) : QWidget(parent)
 {
-	mPixmapHeight = 24;
+	mPixmapHeight = 18;
 
 	setSizePolicy( QSizePolicy::Maximum, QSizePolicy::Maximum );
 
@@ -57,7 +57,7 @@ BatteryStatusWidget::BatteryStatusWidget(QWidget* parent) : QWidget(parent)
 	mTextLabel = new QLabel();
 	mTextLabel->setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Fixed );
 	QFont timeFont = mTextLabel->font();
-	timeFont.setPixelSize(20);
+	timeFont.setPixelSize(14);
 	mTextLabel->setFont(timeFont);
 	mainLayout->addWidget( mTextLabel, 0, Qt::AlignLeft | Qt::AlignHCenter );
 
@@ -153,7 +153,7 @@ void BatteryStatusWidget::SetStatus(double normalizedLevel, EStatus status)
 	if (mBatteryStatus == STATUS_UNKNOWN)
 		mTempString = "";
 	else
-		mTempString.Format( "%.0f %%", mBatteryLevel * 100.0 );
+		mTempString.Format( "%.0f%%", mBatteryLevel * 100.0 );
 
 	mTextLabel->setText( mTempString.AsChar() );
 

--- a/src/Studio/Widgets/ImpedanceTestWidget.cpp
+++ b/src/Studio/Widgets/ImpedanceTestWidget.cpp
@@ -29,7 +29,7 @@
 
 using namespace Core;
 
-// impedance profiles
+// impedance quality profiles
 ImpedanceTestWidget::Threshold ImpedanceTestWidget::Thresholds[] = {
    ImpedanceTestWidget::Threshold("Research",        5.0,  10.0,  20.0,  80.0), 
    ImpedanceTestWidget::Threshold("Neurofeedback",  10.0,  20.0,  40.0,  80.0), 
@@ -38,7 +38,7 @@ ImpedanceTestWidget::Threshold ImpedanceTestWidget::Thresholds[] = {
 
 // constructor
 ImpedanceTestWidget::ImpedanceTestWidget(BciDevice* device, QWidget* parent) : QWidget(parent), 
-	mImpedanceThreshold(&Thresholds[DEFAULTPROFILE]),
+	mImpedanceThreshold(&ImpedanceTestWidget::Thresholds[DEFAULTPROFILE]),
 	mPixmapPass(GetQtBaseManager()->FindIcon("Images/Icons/SuccessCircled.png").pixmap(20, 20)),
 	mPixmapFail(GetQtBaseManager()->FindIcon("Images/Icons/FailCircled.png").pixmap(20, 20))
 {

--- a/src/Studio/Widgets/ImpedanceTestWidget.cpp
+++ b/src/Studio/Widgets/ImpedanceTestWidget.cpp
@@ -196,7 +196,7 @@ void ImpedanceTestWidget::OnThresholdSelected(int index)
 	if (index >= NUMPROFILES)
 		return;
 
-	mImpedanceThreshold = &Thresholds[index];
+	mImpedanceThreshold = &ImpedanceTestWidget::Thresholds[index];
 
 	String s;
 	s.Format("%s THRESHOLDS\n GREEN\t\t< %i kOhm\n YELLOW\t< %i kOhm\n ORANGE\t< %i kOhm\n RED\t\t< %i kOhm",

--- a/src/Studio/Widgets/ImpedanceTestWidget.cpp
+++ b/src/Studio/Widgets/ImpedanceTestWidget.cpp
@@ -29,9 +29,17 @@
 
 using namespace Core;
 
+// impedance/signalquality profiles
+ImpedanceTestWidget::Threshold ImpedanceTestWidget::Thresholds[] = {
+   ImpedanceTestWidget::Threshold("Research",        5.0,  10.0,  20.0,  80.0),
+   ImpedanceTestWidget::Threshold("Neurofeedback",  10.0,  20.0,  40.0,  80.0),
+   ImpedanceTestWidget::Threshold("Testing",       100.0, 200.0, 300.0, 400.0)
+};
+
+
 // constructor
 ImpedanceTestWidget::ImpedanceTestWidget(BciDevice* device, QWidget* parent) : QWidget(parent), 
-	mImpedanceThreshold(&BciDevice::ImpedanceThresholds[BciDevice::DEFAULTIMPEDANCEPROFILE]),
+	mImpedanceThreshold(&Thresholds[DEFAULTIMPEDANCEPROFILE]),
 	mPixmapPass(GetQtBaseManager()->FindIcon("Images/Icons/SuccessCircled.png").pixmap(20, 20)),
 	mPixmapFail(GetQtBaseManager()->FindIcon("Images/Icons/FailCircled.png").pixmap(20, 20))
 {
@@ -66,17 +74,17 @@ ImpedanceTestWidget::ImpedanceTestWidget(BciDevice* device, QWidget* parent) : Q
 
 	mThresholdComboBox = new QComboBox();
 	mThresholdComboBox->setEditable(false);
-	mThresholdComboBox->setMaxCount(BciDevice::NUMIMPEDANCEPROFILES);
-	for (size_t i = 0; i < BciDevice::NUMIMPEDANCEPROFILES; i++)
-		mThresholdComboBox->addItem(BciDevice::ImpedanceThresholds[i].name);
+	mThresholdComboBox->setMaxCount(NUMIMPEDANCEPROFILES);
+	for (size_t i = 0; i < NUMIMPEDANCEPROFILES; i++)
+		mThresholdComboBox->addItem(Thresholds[i].name);
 
 	connect(mThresholdComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(OnThresholdSelected(int)));
 	connect(mThresholdComboBox, SIGNAL(editTextChanged(const QString&)), this, SLOT(OnThresholdEdited(const QString&)));
 	mThresholdComboBox->setFixedWidth(100);
 	mainLayout->addWidget(mThresholdComboBox, 1, 1, 1, 1);
 	// select default threshold
-	mThresholdComboBox->setCurrentIndex(BciDevice::DEFAULTIMPEDANCEPROFILE);
-	OnThresholdSelected(BciDevice::DEFAULTIMPEDANCEPROFILE);
+	mThresholdComboBox->setCurrentIndex(DEFAULTIMPEDANCEPROFILE);
+	OnThresholdSelected(DEFAULTIMPEDANCEPROFILE);
 
 	// Row 3
 	QLabel* passedlbl = new QLabel("Passed:");
@@ -186,10 +194,10 @@ void ImpedanceTestWidget::UpdateInterface()
 // threshold combobox selection changed
 void ImpedanceTestWidget::OnThresholdSelected(int index)
 {
-	if (index >= BciDevice::NUMIMPEDANCEPROFILES)
+	if (index >= NUMIMPEDANCEPROFILES)
 		return;
 
-	mImpedanceThreshold = &BciDevice::ImpedanceThresholds[index];
+	mImpedanceThreshold = &Thresholds[index];
 
 	String s;
 	s.Format("%s THRESHOLDS\n GREEN\t\t< %i kOhm\n YELLOW\t< %i kOhm\n ORANGE\t< %i kOhm\n RED\t\t< %i kOhm",
@@ -212,11 +220,11 @@ void ImpedanceTestWidget::OnThresholdEdited(const QString& text)
 
 void ImpedanceTestWidget::SetThresholdFromText(const QString& text)
 {
-	for (size_t i = 0; i < BciDevice::NUMIMPEDANCEPROFILES; i++) 
+	for (size_t i = 0; i < NUMIMPEDANCEPROFILES; i++) 
 	{
-		if (text == BciDevice::ImpedanceThresholds[i].name)
+		if (text == Thresholds[i].name)
 		{
-			mImpedanceThreshold = &BciDevice::ImpedanceThresholds[i];
+			mImpedanceThreshold = &Thresholds[i];
 			return;
 		}
 	}

--- a/src/Studio/Widgets/ImpedanceTestWidget.cpp
+++ b/src/Studio/Widgets/ImpedanceTestWidget.cpp
@@ -29,17 +29,16 @@
 
 using namespace Core;
 
-// impedance/signalquality profiles
+// impedance profiles
 ImpedanceTestWidget::Threshold ImpedanceTestWidget::Thresholds[] = {
-   ImpedanceTestWidget::Threshold("Research",        5.0,  10.0,  20.0,  80.0),
-   ImpedanceTestWidget::Threshold("Neurofeedback",  10.0,  20.0,  40.0,  80.0),
+   ImpedanceTestWidget::Threshold("Research",        5.0,  10.0,  20.0,  80.0), 
+   ImpedanceTestWidget::Threshold("Neurofeedback",  10.0,  20.0,  40.0,  80.0), 
    ImpedanceTestWidget::Threshold("Testing",       100.0, 200.0, 300.0, 400.0)
 };
 
-
 // constructor
 ImpedanceTestWidget::ImpedanceTestWidget(BciDevice* device, QWidget* parent) : QWidget(parent), 
-	mImpedanceThreshold(&Thresholds[DEFAULTIMPEDANCEPROFILE]),
+	mImpedanceThreshold(&Thresholds[DEFAULTPROFILE]),
 	mPixmapPass(GetQtBaseManager()->FindIcon("Images/Icons/SuccessCircled.png").pixmap(20, 20)),
 	mPixmapFail(GetQtBaseManager()->FindIcon("Images/Icons/FailCircled.png").pixmap(20, 20))
 {
@@ -74,8 +73,8 @@ ImpedanceTestWidget::ImpedanceTestWidget(BciDevice* device, QWidget* parent) : Q
 
 	mThresholdComboBox = new QComboBox();
 	mThresholdComboBox->setEditable(false);
-	mThresholdComboBox->setMaxCount(NUMIMPEDANCEPROFILES);
-	for (size_t i = 0; i < NUMIMPEDANCEPROFILES; i++)
+	mThresholdComboBox->setMaxCount(NUMPROFILES);
+	for (size_t i = 0; i < NUMPROFILES; i++)
 		mThresholdComboBox->addItem(Thresholds[i].name);
 
 	connect(mThresholdComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(OnThresholdSelected(int)));
@@ -83,8 +82,8 @@ ImpedanceTestWidget::ImpedanceTestWidget(BciDevice* device, QWidget* parent) : Q
 	mThresholdComboBox->setFixedWidth(100);
 	mainLayout->addWidget(mThresholdComboBox, 1, 1, 1, 1);
 	// select default threshold
-	mThresholdComboBox->setCurrentIndex(DEFAULTIMPEDANCEPROFILE);
-	OnThresholdSelected(DEFAULTIMPEDANCEPROFILE);
+	mThresholdComboBox->setCurrentIndex(DEFAULTPROFILE);
+	OnThresholdSelected(DEFAULTPROFILE);
 
 	// Row 3
 	QLabel* passedlbl = new QLabel("Passed:");
@@ -194,7 +193,7 @@ void ImpedanceTestWidget::UpdateInterface()
 // threshold combobox selection changed
 void ImpedanceTestWidget::OnThresholdSelected(int index)
 {
-	if (index >= NUMIMPEDANCEPROFILES)
+	if (index >= NUMPROFILES)
 		return;
 
 	mImpedanceThreshold = &Thresholds[index];
@@ -220,7 +219,7 @@ void ImpedanceTestWidget::OnThresholdEdited(const QString& text)
 
 void ImpedanceTestWidget::SetThresholdFromText(const QString& text)
 {
-	for (size_t i = 0; i < NUMIMPEDANCEPROFILES; i++) 
+	for (size_t i = 0; i < NUMPROFILES; i++) 
 	{
 		if (text == Thresholds[i].name)
 		{

--- a/src/Studio/Widgets/ImpedanceTestWidget.h
+++ b/src/Studio/Widgets/ImpedanceTestWidget.h
@@ -44,23 +44,6 @@ class ImpedanceTestWidget : public QWidget
 
 		void UpdateInterface();
 
-		class Threshold
-		{
-		public:
-			const char*  name;
-			const double green;
-			const double yellow;
-			const double orange;
-			const double red;
-			inline Threshold(const char* n, double g = 0.0, double y = 0.0, double o = 0.0, double r = 0.0) :
-				name(n), green(g), yellow(y), orange(o), red(r) { }
-		};
-
-		static constexpr const size_t NUMPROFILES    = 3;
-		static constexpr const size_t DEFAULTPROFILE = 1;
-
-		static Threshold Thresholds[NUMPROFILES];
-
 	private slots:
 		void OnThresholdSelected(int index);
 		void OnThresholdEdited(const QString& text);
@@ -71,16 +54,13 @@ class ImpedanceTestWidget : public QWidget
 		BciDevice*		mDevice;
 		Core::String	mTempString;
 
-		Threshold*		mImpedanceThreshold;
+		BciDevice::ImpedanceThreshold*		mImpedanceThreshold;
 
 		QComboBox*		mThresholdComboBox;
-		QLabel*			mMinImpedanceLabel;
-		QLabel*			mMaxImpedanceLabel;
-		QLabel*			mAvgImpedanceLabel;
 
-		QLabel*			mPassIconLabel;
-		QLabel*			mFailIconLabel;
-		
+		QPixmap			mPixmapPass;
+		QPixmap			mPixmapFail;
+		QLabel*			mTestLabel;
 };
 
 

--- a/src/Studio/Widgets/ImpedanceTestWidget.h
+++ b/src/Studio/Widgets/ImpedanceTestWidget.h
@@ -36,7 +36,14 @@
 
 class ImpedanceTestWidget : public QWidget
 {
+	Q_OBJECT
 	public:
+		// constructor & destructor
+		ImpedanceTestWidget(BciDevice* device, QWidget* parent=NULL);
+		virtual ~ImpedanceTestWidget();
+
+		void UpdateInterface();
+
 		// impedance/signalquality threshold set
 		class Threshold
 		{
@@ -54,14 +61,6 @@ class ImpedanceTestWidget : public QWidget
 		static constexpr const size_t DEFAULTPROFILE = 1;
 
 		static Threshold Thresholds[NUMPROFILES];
-
-	Q_OBJECT
-	public:
-		// constructor & destructor
-		ImpedanceTestWidget(BciDevice* device, QWidget* parent=NULL);
-		virtual ~ImpedanceTestWidget();
-
-		void UpdateInterface();
 
 	private slots:
 		void OnThresholdSelected(int index);

--- a/src/Studio/Widgets/ImpedanceTestWidget.h
+++ b/src/Studio/Widgets/ImpedanceTestWidget.h
@@ -44,7 +44,6 @@ class ImpedanceTestWidget : public QWidget
 
 		void UpdateInterface();
 
-		// impedance/signalquality threshold set
 		class Threshold
 		{
 		public:

--- a/src/Studio/Widgets/ImpedanceTestWidget.h
+++ b/src/Studio/Widgets/ImpedanceTestWidget.h
@@ -50,10 +50,10 @@ class ImpedanceTestWidget : public QWidget
 				name(n), green(g), yellow(y), orange(o), red(r) { }
 		};
 
-		static constexpr const size_t NUMIMPEDANCEPROFILES    = 3;
-		static constexpr const size_t DEFAULTIMPEDANCEPROFILE = 1;
+		static constexpr const size_t NUMPROFILES    = 3;
+		static constexpr const size_t DEFAULTPROFILE = 1;
 
-		static Threshold Thresholds[NUMIMPEDANCEPROFILES];
+		static Threshold Thresholds[NUMPROFILES];
 
 	Q_OBJECT
 	public:
@@ -77,9 +77,9 @@ class ImpedanceTestWidget : public QWidget
 
 		QComboBox*		mThresholdComboBox;
 
+		QLabel*			mTestLabel;
 		QPixmap			mPixmapPass;
 		QPixmap			mPixmapFail;
-		QLabel*			mTestLabel;
 };
 
 

--- a/src/Studio/Widgets/ImpedanceTestWidget.h
+++ b/src/Studio/Widgets/ImpedanceTestWidget.h
@@ -36,6 +36,25 @@
 
 class ImpedanceTestWidget : public QWidget
 {
+	public:
+		// impedance/signalquality threshold set
+		class Threshold
+		{
+		public:
+			const char*  name;
+			const double green;
+			const double yellow;
+			const double orange;
+			const double red;
+			inline Threshold(const char* n, double g = 0.0, double y = 0.0, double o = 0.0, double r = 0.0) :
+				name(n), green(g), yellow(y), orange(o), red(r) { }
+		};
+
+		static constexpr const size_t NUMIMPEDANCEPROFILES    = 3;
+		static constexpr const size_t DEFAULTIMPEDANCEPROFILE = 1;
+
+		static Threshold Thresholds[NUMIMPEDANCEPROFILES];
+
 	Q_OBJECT
 	public:
 		// constructor & destructor
@@ -54,7 +73,7 @@ class ImpedanceTestWidget : public QWidget
 		BciDevice*		mDevice;
 		Core::String	mTempString;
 
-		BciDevice::ImpedanceThreshold*		mImpedanceThreshold;
+		Threshold*		mImpedanceThreshold;
 
 		QComboBox*		mThresholdComboBox;
 

--- a/src/Studio/Widgets/SignalQualityWidget.cpp
+++ b/src/Studio/Widgets/SignalQualityWidget.cpp
@@ -32,7 +32,7 @@ using namespace Core;
 // constructor
 SignalQualityWidget::SignalQualityWidget(QWidget* parent) : QWidget(parent)
 {
-	mPixmapHeight = 24;
+	mPixmapHeight = 18;
 
 	setSizePolicy( QSizePolicy::Maximum, QSizePolicy::Maximum );
 
@@ -57,7 +57,7 @@ SignalQualityWidget::SignalQualityWidget(QWidget* parent) : QWidget(parent)
 	mTextLabel = new QLabel();
 	mTextLabel->setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Fixed );
 	QFont timeFont = mTextLabel->font();
-	timeFont.setPixelSize(20);
+	timeFont.setPixelSize(14);
 	mTextLabel->setFont(timeFont);
 	mainLayout->addWidget( mTextLabel, 0, Qt::AlignLeft | Qt::AlignHCenter );
 
@@ -103,7 +103,7 @@ void SignalQualityWidget::SetSignalQuality(double normalizedSignalQuality)
 	// update the signal quality
 	mSignalQuality = normalizedSignalQuality;
 
-	mTempString.Format( "%.0f %%", normalizedSignalQuality * 100.0 );
+	mTempString.Format( "%.0f%%", normalizedSignalQuality * 100.0 );
 	mTextLabel->setText( mTempString.AsChar() );
 
 	const int32 pixmapIndex = normalizedSignalQuality * mPixmaps.Size() - Math::epsilon;


### PR DESCRIPTION
**FIXES**
* Sets default EEG channel buffer size to 60 seconds which is also the max. in the `Raw EEG` view settings.
  * Fixes the Raw EEG plot sometimes not rendered to the left end of the timeline

**IMPROVEMENTS**
* Adds two new branding settings
  * `HasColorCodesForChannels` activates a special coloring for channels in `Devices` view
  * `HasMinimalDeviceInfo` limits info table in `Devices` view to most important stats
* Major refactoring of the `Devices` view and the impedance check in it, adding a table for up to 8 impedances, rearranging elements, supporting background impedance checks and more

Few other things...