### PR TITLE
Tweaks for OpenBCI with Daisy

### DIFF
--- a/src/Engine/Devices/OpenBCI/OpenBCIDevices.cpp
+++ b/src/Engine/Devices/OpenBCI/OpenBCIDevices.cpp
@@ -139,22 +139,22 @@ void OpenBCIDaisyDevice::CreateElectrodes()
 	mElectrodes.Clear();
 	mElectrodes.Reserve(NUMELECTRODESDAISY);
 
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("P3"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("P4"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("Oz"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("Fz"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("T5"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("T6"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("F3"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("F4"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("T3"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("T4"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("C3"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("C4"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("Cz"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("O1"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("O2"));
-	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("Pz"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("1"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("2"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("3"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("4"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("5"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("6"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("7"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("8"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("9"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("10"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("11"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("12"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("13"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("14"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("15"));
+	mElectrodes.Add(GetEEGElectrodes()->GetElectrodeByID("16"));
 }
 
 #endif

--- a/src/Engine/Devices/OpenBCI/OpenBCIDevices.h
+++ b/src/Engine/Devices/OpenBCI/OpenBCIDevices.h
@@ -87,6 +87,7 @@ public:
    double GetExpectedJitter() const override { return 0.1; }
    bool IsWireless() const override          { return true; }
    bool HasTestMode() const override         { return false; }
+   double GetTimeoutLimit() const override   { return 60; }
 
    void CreateSensors() override;
 
@@ -132,8 +133,6 @@ public:
    const char* GetUuid() const override							{ return "5108993a-fe1b-11e4-a322-1697f925ec7b"; }
    static const char* GetRuleName()								{ return "DEVICE_OpenBCI"; }
    double GetSampleRate() const override							{ return SAMPLERATECYTON; }
-
-   double GetTimeoutLimit() const override							{ return 60; } // Long timeout limit because channel config takes so long
 
    void CreateElectrodes() override;
 


### PR DESCRIPTION
**Tweaks for OpenBCI with Daisy**
* Changes channel names to numeric `1-16` numbers like on OpenBCI alone
* Sets large timeout like on OpenBCI alone (fixes device getting removed before fully connect)